### PR TITLE
Fix NoClassDefFoundError when run without xstream

### DIFF
--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -274,7 +274,7 @@ public class ChronicleMapBuilder<K, V> implements Cloneable,
         try {
             xStreamClass =
                     Class.forName("net.openhft.xstream.MapHeaderSerializationXStream");
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
             xStreamClass = null;
         }
         if (xStreamClass == null) {


### PR DESCRIPTION
When run it without xstream it meets NoClassDefFoundError
```java
Exception in thread "main" java.lang.NoClassDefFoundError: com/thoughtworks/xstream/XStream
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:449)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:71)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:190)
	at net.openhft.chronicle.map.ChronicleMapBuilder.trySerializeHeaderViaXStream(ChronicleMapBuilder.java:275)
	at net.openhft.chronicle.map.ChronicleMapBuilder.createWithFile(ChronicleMapBuilder.java:1320)
	at net.openhft.chronicle.map.ChronicleMapBuilder.createPersistedTo(ChronicleMapBuilder.java:1250)
```