### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Click here to get the [Latest Version Number](http://search.maven.org/#search%7C
 
 ### Overview
 Chronicle Map implements the interface `java.util.concurrent.ConcurrentMap`, however unlike the standard
-jdk implementations, ChronicleMap is both persistent and able to share your entries accross processes:
+jdk implementations, ChronicleMap is both persistent and able to share your entries across processes:
 
 ![](http://chronicle.software/wp-content/uploads/2014/07/Chronicle-Map-diagram_04.jpg)
 


### PR DESCRIPTION
@OpenHFT, I've corrected a typographical error in the documentation of the [Chronicle-Map](https://github.com/OpenHFT/Chronicle-Map) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.