### PR TITLE
Fix urls in spec/README.md

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -4,7 +4,7 @@ This directory contains the Chronicle Map specification.
 
 This is currently work-in-progress.
 
- - [Rational behind this Specification](0_purposes.md)
- - [Design Goals, Assumptions and Guarantees](1_design_goals.md)
- - [Design overview](2_design_overview.md)
+ - [Rational behind this Specification](0-purposes.md)
+ - [Design Goals, Assumptions and Guarantees](1-design-goals.md)
+ - [Design overview](2-design-overview.md)
  - [Memory layout](3-memory-layout.md)


### PR DESCRIPTION
Hey,

Noticed the URLs in /spec/README.md were broken due to underscores instead of dashes. 

Cheers,
Parreira