### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/LogHolder.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/LogHolder.java
@@ -22,5 +22,10 @@ import org.slf4j.LoggerFactory;
 
 @Staged
 public class LogHolder {
+    
+    private LogHolder() {
+        
+    }
+    
     public static final Logger LOG = LoggerFactory.getLogger(LogHolder.class);
 }

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/CanonicalRandomAccessFiles.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/CanonicalRandomAccessFiles.java
@@ -25,6 +25,10 @@ import java.io.RandomAccessFile;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class CanonicalRandomAccessFiles {
+    
+    private CanonicalRandomAccessFiles() {
+        
+    }
 
     private static class RafReference {
         RandomAccessFile raf;

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/PoissonDistribution.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/PoissonDistribution.java
@@ -20,6 +20,10 @@ package net.openhft.chronicle.hash.impl.util.math;
 
 
 public class PoissonDistribution {
+    
+    private PoissonDistribution() {
+        
+    }
 
     private static final double EPSILON = 1e-12;
     /**

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
@@ -19,6 +19,10 @@
 package net.openhft.chronicle.hash.impl.util.math;
 
 class Precision {
+    
+    private Precision() {
+        
+    }
 
     /** Offset to order signed double numbers lexicographically. */
     private static final long SGN_MASK = 0x8000000000000000L;

--- a/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
+++ b/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
@@ -32,6 +32,10 @@ import java.util.zip.GZIPOutputStream;
  * @author Rob Austin.
  */
 class JsonSerializer {
+    
+    private JsonSerializer() {
+        
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(JsonSerializer.class);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed