### PR TITLE
Code quality fix - Methods named "equals" should override Object.equals(Object). 

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/ContinuedFraction.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/ContinuedFraction.java
@@ -79,7 +79,7 @@ abstract class ContinuedFraction {
         double hPrev = getA(0, x);
 
         // use the value of small as epsilon criteria for zero checks
-        if (Precision.equals(hPrev, 0.0, small)) {
+        if (Precision.isEquals(hPrev, 0.0, small)) {
             hPrev = small;
         }
 
@@ -93,11 +93,11 @@ abstract class ContinuedFraction {
             final double b = getB(n, x);
 
             double dN = a + b * dPrev;
-            if (Precision.equals(dN, 0.0, small)) {
+            if (Precision.isEquals(dN, 0.0, small)) {
                 dN = small;
             }
             double cN = a + b / cPrev;
-            if (Precision.equals(cN, 0.0, small)) {
+            if (Precision.isEquals(cN, 0.0, small)) {
                 cN = small;
             }
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
@@ -38,8 +38,8 @@ class Precision {
      * @return {@code true} if the values are two adjacent floating point
      * numbers or they are within range of each other.
      */
-    public static boolean equals(double x, double y, double eps) {
-        return equals(x, y, 1) || Math.abs(y - x) <= eps;
+    public static boolean isEquals(double x, double y, double eps) {
+        return isEquals(x, y, 1) || Math.abs(y - x) <= eps;
     }
 
     /**
@@ -63,7 +63,7 @@ class Precision {
      * @return {@code true} if there are fewer than {@code maxUlps} floating
      * point values between {@code x} and {@code y}.
      */
-    public static boolean equals(final double x, final double y, final int maxUlps) {
+    public static boolean isEquals(final double x, final double y, final int maxUlps) {
 
         final long xInt = Double.doubleToRawLongBits(x);
         final long yInt = Double.doubleToRawLongBits(y);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1201 - Methods named "equals" should override Object.equals(Object). 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1201

Please let me know if you have any questions.

Faisal Hameed