### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
@@ -69,7 +69,7 @@ class Precision {
         final long yInt = Double.doubleToRawLongBits(y);
 
         final boolean isEqual;
-        if (((xInt ^ yInt) & SGN_MASK) == 0l) {
+        if (((xInt ^ yInt) & SGN_MASK) == 0L) {
             // number have same sign, there is no risk of overflow
             isEqual = Math.abs(xInt - yInt) <= maxUlps;
         } else {

--- a/src/main/java/net/openhft/xstream/converters/AbstractChronicleMapConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/AbstractChronicleMapConverter.java
@@ -119,14 +119,14 @@ class AbstractChronicleMapConverter<K, V> implements Converter {
         switch (reader.getNodeName()) {
 
             case "java.util.Collections$EmptySet":
-                return (E) Collections.EMPTY_SET;
+                return (E) Collections.emptySet();
 
             case "java.util.Collections$EmptyList":
-                return (E) Collections.EMPTY_LIST;
+                return (E) Collections.emptyList();
 
             case "java.util.Collections$EmptyMap":
             case "java.util.Collections.EmptyMap":
-                return (E) Collections.EMPTY_MAP;
+                return (E) Collections.emptyMap();
 
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of 
Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET,
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck

Please let me know if you have any questions.

Faisal Hameed