### PR TITLE
Fix a few Javadoc typos

### DIFF
--- a/src/test/java/net/openhft/chronicle/map/jsr166/JSR166TestCase.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/JSR166TestCase.java
@@ -542,7 +542,7 @@ public class JSR166TestCase {
     /**
      * android-changed
      * Android does not use a SecurityManager. This will simply execute
-     * the runnable ingoring permisions.
+     * the runnable ignoring permissions.
      */
     public void runWithPermissions(Runnable r, Permission... permissions) {
         r.run();
@@ -551,7 +551,7 @@ public class JSR166TestCase {
     /**
      * android-changed
      * Android does not use a SecurityManager. This will simply execute
-     * the runnable ingoring permisions.
+     * the runnable ignoring permissions.
      */
     public void runWithSecurityManagerWithPermissions(Runnable r,
                                                       Permission... permissions) {

--- a/src/test/java/net/openhft/chronicle/map/utility/ProcessInstanceLimiter.java
+++ b/src/test/java/net/openhft/chronicle/map/utility/ProcessInstanceLimiter.java
@@ -108,7 +108,7 @@ public class ProcessInstanceLimiter implements Runnable {
 
     /**
      * Create a ProcessInstanceLimiter instance with a default callback, an
-     * instance of "DefaultCallback", and using the default shareed file named
+     * instance of "DefaultCallback", and using the default shared file named
      * ProcessInstanceLimiter_DEFAULT_SHARED_MAP_ in the temp directory.
      *
      * @throws IOException - if the default shared file cannot be created
@@ -131,7 +131,7 @@ public class ProcessInstanceLimiter implements Runnable {
     }
 
     /**
-     * Create a ProcessInstanceLimiter instance using the default shareed file
+     * Create a ProcessInstanceLimiter instance using the default shared file
      * named ProcessInstanceLimiter_DEFAULT_SHARED_MAP_ in the tmp directory.
      *
      * @param sharedMapPath - The path to a file which will be used to store the shared


### PR DESCRIPTION
I found a few Javadoc typos and fixed them