### PR TITLE
try to preallocate space after RandomAccessFile#setLength()

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -17,7 +17,6 @@
 
 package net.openhft.chronicle.hash.impl;
 
-import com.sun.jna.Platform;
 import net.openhft.chronicle.algo.locks.*;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.MappedBytesStoreFactory;
@@ -964,7 +963,7 @@ public abstract class VanillaChronicleHash<K,
             // This kind of fragmented file may hang the program and cause dmesg reports
             // "XFS: ... possible memory allocation deadlock size ... in kmem_alloc (mode:0x250)".
             // We can fix this by trying calling posix_fallocate to preallocate the space.
-            if (Platform.isLinux()) {
+            if (OS.isLinux()) {
                 PosixFallocate.fallocate(raf.getFD(), 0, minFileSize);
             }
         }

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/jna/PosixFallocate.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/jna/PosixFallocate.java
@@ -1,0 +1,46 @@
+package net.openhft.chronicle.hash.impl.util.jna;
+
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileDescriptor;
+import java.lang.reflect.Field;
+
+public final class PosixFallocate {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PosixFallocate.class.getName());
+
+    static {
+        Native.register(Platform.C_LIBRARY_NAME);
+    }
+
+    private PosixFallocate() {
+    }
+
+    public static void fallocate(FileDescriptor descriptor, long offset, long length) {
+        int fd = getNativeFileDescriptor(descriptor);
+        if (fd != -1) {
+            int ret = posix_fallocate(getNativeFileDescriptor(descriptor), offset, length);
+            if (ret != 0) {
+                LOG.warn("posix_fallocate() returned {}", ret);
+            }
+        }
+    }
+
+    private static native int posix_fallocate(int fd, long offset, long length);
+
+    private static int getNativeFileDescriptor(FileDescriptor descriptor) {
+        try {
+            final Field field = descriptor.getClass().getDeclaredField("fd");
+            field.setAccessible(true);
+            return (int) field.get(descriptor);
+        } catch (final Exception e) {
+            LOG.warn("unsupported FileDescriptor implementation: e={}", e.getLocalizedMessage());
+            return -1;
+        }
+    }
+
+}


### PR DESCRIPTION
RandomAccessFile#setLength() only calls ftruncate,
which will not preallocate space on XFS filesystem of Linux.
And writing that file will create a sparse file with a large number of extents.
This kind of fragmented file may hang the program and cause dmesg reports
"XFS: ... possible memory allocation deadlock size ... in kmem_alloc (mode:0x250)".
We can fix this by trying calling posix_fallocate to preallocate the space.

We found this problem in our production environment on CentOS 7.
A large number of extents were created
because random writes to the hashmap were turned into sequentail writes to the disk.
After applying this patch, the file created contains only 2 extents.