### PR TITLE
add pre-shutdown action to be executed inside ChronicleHashCloseOnExitHook

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Base interface for {@link ChronicleMapBuilder} and {@link ChronicleSetBuilder}, i. e. defines
@@ -744,6 +745,22 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
     H recoverPersistedTo(
             File file, boolean sameBuilderConfigAndLibraryVersion,
             ChronicleHashCorruption.Listener corruptionListener) throws IOException;
+
+    /**
+     * A {@link ChronicleHash} created using this builder is closed using a JVM shutdown hook.
+     * This method lets you perform an action before the {@link ChronicleHash} is closed.
+     * <p>
+     * <p>The registered action is not executed when JVM is running and a
+     * {@link ChronicleHash#close()} is explicitly called.
+     * <p>
+     * <p>Example usage of this call: To carry out a graceful shutdown and explicitly
+     * control when the {@link ChronicleHash} is closed, the action can be a wait on a
+     * {@link CountDownLatch} that would be released appropriately.
+     *
+     * @param preShutdownAction action to run before closing the {@link ChronicleHash} in a
+     *                          JVM shutdown hook.
+     */
+    void setPreShutdownAction(Runnable preShutdownAction);
 
     /**
      * @deprecated don't use private API in the client code

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilderPrivateAPI.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilderPrivateAPI.java
@@ -90,4 +90,12 @@ public interface ChronicleHashBuilderPrivateAPI<K, RO> {
     void removedEntryCleanupTimeout(long removedEntryCleanupTimeout, TimeUnit unit);
 
     void remoteOperations(RO remoteOperations);
+
+    /**
+     * Provides registered action to be executed before closing a {@link ChronicleHash} in a JVM
+     * shutdown hook.
+     *
+     * @return registered pre-shutdown action.
+     */
+    Runnable getPreShutdownAction();
 }

--- a/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashCloseOnExitHook.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashCloseOnExitHook.java
@@ -60,6 +60,20 @@ final class ChronicleHashCloseOnExitHook {
             // close later added maps first
             orderedMaps.descendingMap().values().forEach(h -> {
                 try {
+                    Runnable preShutdownAction = h.getPreShutdownAction();
+                    if (preShutdownAction != null) {
+                        try {
+                            preShutdownAction.run();
+                        } catch (Throwable throwable) {
+                            try {
+                                LOG.error("Error running pre-shutdown action for " + h.toIdentityString() +
+                                        " :", throwable);
+                            } catch (Throwable t2) {
+                                throwable.addSuppressed(t2);
+                                throwable.printStackTrace();
+                            }
+                        }
+                    }
                     h.close();
                 } catch (Throwable throwable) {
                     try {

--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -125,6 +125,7 @@ public abstract class VanillaChronicleHash<K,
     public transient CompactOffHeapLinearHashTable hashLookup;
     public transient Identity identity;
     protected int log2TiersInBulk;
+    private Runnable preShutdownAction;
     /////////////////////////////////////////////////
     // Bytes Store (essentially, the base address) and serialization-dependent offsets
     protected transient BytesStore bs;
@@ -208,6 +209,8 @@ public abstract class VanillaChronicleHash<K,
         tierBulkSizeInBytes = computeTierBulkBytesSize(tiersInBulk);
 
         checksumEntries = privateAPI.checksumEntries();
+
+        preShutdownAction = privateAPI.getPreShutdownAction();
     }
 
     public static IOException throwRecoveryOrReturnIOException(
@@ -228,6 +231,10 @@ public abstract class VanillaChronicleHash<K,
     public void readMarshallable(@NotNull WireIn wire) {
         readMarshallableFields(wire);
         initTransients();
+    }
+
+    public Runnable getPreShutdownAction() {
+        return preShutdownAction;
     }
 
     protected void readMarshallableFields(@NotNull WireIn wireIn) {

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -181,6 +181,7 @@ public final class ChronicleMapBuilder<K, V> implements
     MapMethods<K, V, ?> methods = DefaultSpi.mapMethods();
     MapEntryOperations<K, V, ?> entryOperations = mapEntryOperations();
     MapRemoteOperations<K, V, ?> remoteOperations = mapRemoteOperations();
+    Runnable preShutdownAction;
     private String name;
     // not final because of cloning
     private ChronicleMapBuilderPrivateAPI<K, V> privateAPI =
@@ -1585,6 +1586,11 @@ public final class ChronicleMapBuilder<K, V> implements
             ChronicleHashCorruption.Listener corruptionListener) throws IOException {
         return clone().createWithFile(file, true, sameBuilderConfigAndLibraryVersion,
                 corruptionListener);
+    }
+
+    @Override
+    public void setPreShutdownAction(Runnable preShutdownAction) {
+        this.preShutdownAction = preShutdownAction;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilderPrivateAPI.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilderPrivateAPI.java
@@ -116,4 +116,9 @@ class ChronicleMapBuilderPrivateAPI<K, V>
     public void remoteOperations(MapRemoteOperations<K, V, ?> remoteOperations) {
         b.remoteOperations(remoteOperations);
     }
+
+    @Override
+    public Runnable getPreShutdownAction() {
+        return b.preShutdownAction;
+    }
 }

--- a/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilder.java
+++ b/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilder.java
@@ -353,6 +353,11 @@ public final class ChronicleSetBuilder<K>
         return new SetFromMap<>((VanillaChronicleMap<K, DummyValue, ?>) map);
     }
 
+    @Override
+    public void setPreShutdownAction(Runnable preShutdownAction) {
+        chronicleMapBuilder.setPreShutdownAction(preShutdownAction);
+    }
+
     /**
      * @deprecated don't use private API in the client code
      */

--- a/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilderPrivateAPI.java
+++ b/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilderPrivateAPI.java
@@ -134,4 +134,9 @@ class ChronicleSetBuilderPrivateAPI<K>
             }
         });
     }
+
+    @Override
+    public Runnable getPreShutdownAction() {
+        return mapB.getPreShutdownAction();
+    }
 }


### PR DESCRIPTION
This is useful when we want to do an orderly shutdown.
For example: When jvm needs to shutdown, we may need to do few more CRUD operations
on the ChronicleMap/ChronicleSet. Closing these a using shutdown hook doesn't allow
graceful shutdown where a user can control when the map can be closed.