### PR TITLE
Fix skipCloseOnExitHook setting not persisted

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -38,7 +38,6 @@ import net.openhft.chronicle.map.ChronicleMapBuilder;
 import net.openhft.chronicle.values.Values;
 import net.openhft.chronicle.wire.Marshallable;
 import net.openhft.chronicle.wire.WireIn;
-import net.openhft.chronicle.wire.WireInternal;
 import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
 
@@ -378,6 +377,13 @@ public abstract class VanillaChronicleHash<K,
 
     protected long computeTierBulkInnerOffsetToTiers(long tiersInBulk) {
         return 0L;
+    }
+
+    protected void initTransientsFromBuilder(ChronicleHashBuilder<?, ?, ?> builder) {
+        @SuppressWarnings({"deprecation", "unchecked"})
+        ChronicleHashBuilderPrivateAPI<K, ?> privateAPI =
+                (ChronicleHashBuilderPrivateAPI<K, ?>) builder.privateAPI();
+        preShutdownAction = privateAPI.getPreShutdownAction();
     }
 
     public void initTransients() {

--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -287,6 +287,7 @@ public abstract class VanillaChronicleHash<K,
         tierBulkInnerOffsetToTiers = wireIn.read(() -> "tierBulkInnerOffsetToTiers").int64();
         tiersInBulk = wireIn.read(() -> "tiersInBulk").int64();
         log2TiersInBulk = wireIn.read(() -> "log2TiersInBulk").int32();
+        skipCloseOnExitHook = wireIn.read(() -> "skipCloseOnExitHook").bool();
     }
 
     @Override
@@ -331,6 +332,7 @@ public abstract class VanillaChronicleHash<K,
         wireOut.write(() -> "tierBulkInnerOffsetToTiers").int64(tierBulkInnerOffsetToTiers);
         wireOut.write(() -> "tiersInBulk").int64(tiersInBulk);
         wireOut.write(() -> "log2TiersInBulk").int32(log2TiersInBulk);
+        wireOut.write(() -> "skipCloseOnExitHook").bool(skipCloseOnExitHook);
     }
 
     protected VanillaGlobalMutableState createGlobalMutableState() {

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -19,6 +19,7 @@ package net.openhft.chronicle.map;
 import net.openhft.chronicle.algo.bitset.BitSetFrame;
 import net.openhft.chronicle.algo.bitset.SingleThreadedFlatBitSetFrame;
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.hash.ChronicleHashBuilder;
 import net.openhft.chronicle.hash.Data;
 import net.openhft.chronicle.hash.VanillaGlobalMutableState;
 import net.openhft.chronicle.hash.impl.TierCountersArea;
@@ -189,8 +190,9 @@ public class ReplicatedChronicleMap<K, V, R> extends VanillaChronicleMap<K, V, R
     }
 
     @Override
-    void initTransientsFromBuilder(ChronicleMapBuilder<K, V> builder) {
-        super.initTransientsFromBuilder(builder);
+    protected void initTransientsFromBuilder(ChronicleHashBuilder<?, ?, ?> hashBuilder) {
+        super.initTransientsFromBuilder(hashBuilder);
+        ChronicleMapBuilder<?, ?> builder = (ChronicleMapBuilder<?, ?>) hashBuilder;
         this.localIdentifier = builder.replicationIdentifier;
         //noinspection unchecked
         this.remoteOperations = (MapRemoteOperations<K, V, R>) builder.remoteOperations;

--- a/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
@@ -23,6 +23,7 @@ import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.PointerBytesStore;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.hash.ChronicleHashBuilder;
 import net.openhft.chronicle.hash.ChronicleHashClosedException;
 import net.openhft.chronicle.hash.ChronicleHashCorruption;
 import net.openhft.chronicle.hash.Data;
@@ -150,7 +151,10 @@ public class VanillaChronicleMap<K, V, R>
         wireOut.write(() -> "maxBloatFactor").float64(maxBloatFactor);
     }
 
-    void initTransientsFromBuilder(ChronicleMapBuilder<K, V> builder) {
+    @Override
+    protected void initTransientsFromBuilder(ChronicleHashBuilder<?, ?, ?> hashBuilder) {
+        super.initTransientsFromBuilder(hashBuilder);
+        ChronicleMapBuilder<K, V> builder = (ChronicleMapBuilder<K, V>) hashBuilder;
         name = builder.name();
         putReturnsNull = builder.putReturnsNull();
         removeReturnsNull = builder.removeReturnsNull();


### PR DESCRIPTION
The first commit fixes #213

The second commit fixes the pre-shutdown action not being executed by maps opened with an existing file.