### PR TITLE
Added 'optional' tag for 3 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,16 +129,19 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-aether</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Dependencies in question are:
- com.thoughtworks.xstream:xstream
- org.codehaus.jettison:jettison
- org.ops4j.pax.url:pax-url-aether

1) They are in the so-called `optional` section in pom.xml 
and 
2) LOG statements like 
```
"map.getAll(<file>) and map.putAll(<file>) methods require the JSON XStream serializer, " +
                    "we don't include these artifacts by default as some users don't require this functionality. " +
                    "Please add the following artifacts to your project\n" +
                    "<dependency>\n" +
                    " <groupId>xstream</groupId>\n" +
                    " <artifactId>xstream</artifactId>\n" +
```
suggest that they are indeed optional.

Related to #241. 

Resolves #240.