### PR TITLE
Guard direct memory writes during closing to avoid SEGV

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -724,6 +724,11 @@ public abstract class VanillaChronicleHash<K,
         }
     }
 
+    public void throwExceptionIfClosing() throws IllegalStateException {
+        if (this.isClosing())
+            throw new ChronicleHashClosedException(this.getClass().getName() + " closing", Jvm.getValue(this, "closedHere"));
+    }
+
     @Override
     public void throwExceptionIfClosed() throws IllegalStateException {
         if (this.isClosed())

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -324,7 +324,7 @@ public class ReplicatedChronicleMap<K, V, R> extends VanillaChronicleMap<K, V, R
 
     @Override
     public ModificationIterator acquireModificationIterator(final byte remoteIdentifier) {
-        throwExceptionIfClosed();
+        throwExceptionIfClosing();
 
         ModificationIterator modificationIterator = modificationIterators.get(remoteIdentifier);
         if (modificationIterator != null)


### PR DESCRIPTION
Fixes ChronicleEnterprise/Chronicle-Map-Enterprise#73

best viewed with https://github.com/ChronicleEnterprise/Chronicle-Map-Enterprise/pull/77