### PR TITLE
Resource cleanup

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashResources.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashResources.java
@@ -197,11 +197,12 @@ public abstract class ChronicleHashResources implements Runnable {
         synchronized (this) {
             if (state == COMPLETELY_CLOSED)
                 return false;
+
+            Throwable thrown = releaseEverything(false);
+            if (thrown != null)
+                throw Throwables.propagate(thrown);
         }
 
-        Throwable thrown = releaseEverything(false);
-        if (thrown != null)
-            throw Throwables.propagate(thrown);
         return true;
     }
 

--- a/src/test/java/net/openhft/chronicle/map/NoUpperBoundChunksPerEntryTest.java
+++ b/src/test/java/net/openhft/chronicle/map/NoUpperBoundChunksPerEntryTest.java
@@ -16,13 +16,17 @@
 
 package net.openhft.chronicle.map;
 
+import net.openhft.chronicle.core.OS;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class NoUpperBoundChunksPerEntryTest {
 
     @Test
     public void noUpperBoundChunksPerEntryTest() {
+        Assume.assumeTrue(OS.is64Bit());
+
         ChronicleMap<Integer, CharSequence> map =
                 ChronicleMapBuilder.of(Integer.class, CharSequence.class)
                         .averageValueSize(2).entries(10000L).actualSegments(1).create();


### PR DESCRIPTION
ensure ChronicleHashResources always calls `releaseEverything` inside of a synchronized block