### PR TITLE
Preserve ByteBuffer order in ByteBufferDataAccess.getData.

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccess.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public class ByteBufferDataAccess extends AbstractData<ByteBuffer>
         implements DataAccess<ByteBuffer> {
@@ -85,7 +86,9 @@ public class ByteBufferDataAccess extends AbstractData<ByteBuffer>
     @Override
     public Data<ByteBuffer> getData(@NotNull ByteBuffer instance) {
         bb = instance;
+        ByteOrder originalOrder = instance.order();
         bytesStore = BytesStore.follow(instance);
+        instance.order(originalOrder);
         return this;
     }
 

--- a/src/test/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccessTest.java
@@ -17,10 +17,12 @@
 package net.openhft.chronicle.hash.serialization.impl;
 
 import net.openhft.chronicle.hash.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufferDataAccessTest {
 
@@ -35,7 +37,20 @@ public class ByteBufferDataAccessTest {
         Data<ByteBuffer> data1 = bbDataAccess.getData(bb1);
         ByteBuffer bb2 = ByteBuffer.allocate(2);
         data1.getUsing(bb2);
-        Assert.assertEquals(bb2.get(0), 3);
-        Assert.assertEquals(bb2.get(1), 4);
+        assertEquals(bb2.get(0), 3);
+        assertEquals(bb2.get(1), 4);
+    }
+
+    @Test
+    public void shouldKeepOriginalOrder() {
+        ByteBufferDataAccess da = new ByteBufferDataAccess();
+        ByteBuffer bb = ByteBuffer.allocateDirect(Long.BYTES);
+        ByteOrder originalOrder = bb.order();
+
+        bb.putLong(1L);
+        Data<ByteBuffer> data = da.getData(bb);
+
+        assertEquals(originalOrder, data.get().order());
+        assertEquals(1L, data.get().getLong(0));
     }
 }


### PR DESCRIPTION
Fixes #513 