### PR TITLE
Exceptional-behavior test to cover the throw statement in method 'actualChunksPerSegmentTier'

### DIFF
--- a/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
@@ -2583,6 +2583,12 @@ public class CHMUseCasesTest {
         }
     }
 
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testActualChunksPerSegmentTier() {
+        ChronicleMapBuilder.of(String.class, String.class).actualChunksPerSegmentTier(0);
+    }
+
     enum TypeOfMap {SIMPLE, SIMPLE_PERSISTED}
 
     interface I1 {

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapTest.java
@@ -1881,6 +1881,11 @@ public class ChronicleMapTest {
         }
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalAlignment() {
+	ChronicleMapBuilder.of(IntValue.class, DemoOrderVOInterface.class).entryAndValueOffsetAlignment(13);
+    }
+
     interface BMSUper {
 
     }


### PR DESCRIPTION
Add an exceptional-behavior test to `CHMUseCasesTest.java` to test the `IllegalArgumentException` in method `actualChunksPerSegmentTier`.