### PR TITLE
Exceptional-behavior test to cover the throw statement in method 'actualChunkSize'

### DIFF
--- a/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
@@ -675,6 +675,11 @@ public class CHMUseCasesTest {
         }
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testActualChunkSize() {
+	ChronicleMapBuilder.of(String.class, String.class).actualChunkSize(-1);
+    }
+
     @Test
     public void testAcquireUsingWithIntValueKeyStringBuilderValue() throws IOException {
 


### PR DESCRIPTION
Add an exceptional-behavior test to CHMUseCasesTest.java to test the IllegalArgumentException in method `actualChunkSize` under the condition where the argument is a negative number.