### PR TITLE
Exceptional-behavior test to cover the throw statement in method 'entryAndValueOffsetAlignment'

### DIFF
--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapTest.java
@@ -1881,6 +1881,11 @@ public class ChronicleMapTest {
         }
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeArg() {
+    ChronicleMapBuilder.of(IntValue.class, DemoOrderVOInterface.class).entryAndValueOffsetAlignment(-1);
+    }
+
     interface BMSUper {
 
     }


### PR DESCRIPTION
Add an exceptional-behavior test to ChronicleMapTest.java to test the IllegalArgumentException in method `entryAndValueOffsetAlignment` under the condition where the argument is a negative number.