### PR TITLE
Remove old check.thread.safety property

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,6 +1,5 @@
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=false
-check.thread.safety=false
 # for profiling
 jvm.safepoint.enabled=false
 # for testing sparseFiles


### PR DESCRIPTION
The check.thread.saftety property has not been used for a while. Removing references to it.