### PR TITLE
Don't exit OldDeletedEntriesCleanupThread until a startup delay.

### DIFF
--- a/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
+++ b/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
@@ -114,8 +114,9 @@ class OldDeletedEntriesCleanupThread extends Thread
     public void run() {
         throwExceptionIfClosed();
 
-        if (System.currentTimeMillis() - startTime < 1_000)
-            return;
+        long runningTime = System.currentTimeMillis() - startTime;
+        if (runningTime < 1_000)
+            sleepMillis(1_000 - runningTime);
 
         while (!shutdown) {
             int nextSegmentIndex;

--- a/src/test/java/net/openhft/chronicle/map/MemoryLeaksTest.java
+++ b/src/test/java/net/openhft/chronicle/map/MemoryLeaksTest.java
@@ -69,6 +69,7 @@ public class MemoryLeaksTest {
         builder = ChronicleMap
                 .of(IntValue.class, String.class).constantKeySizeBySample(Values.newHeapInstance(IntValue.class))
                 .valueReaderAndDataAccess(new CountedStringReader(this), new StringUtf8DataAccess());
+        builder.cleanupRemovedEntries(false);
         if (replicated)
             builder.replication((byte) 1);
         builder.entries(1).averageValueSize(10);


### PR DESCRIPTION
Closes https://github.com/OpenHFT/Chronicle-Map/issues/310