### PR TITLE
Add option for putIfAbsentReturnNull to builder

### DIFF
--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -213,6 +213,7 @@ public final class ChronicleMapBuilder<K, V> implements
     private boolean aligned64BitMemoryOperationsAtomic = OS.is64Bit();
     private ChecksumEntries checksumEntries = ChecksumEntries.IF_PERSISTED;
     private boolean putReturnsNull = false;
+    private boolean putIfAbsentUsingValue = false;
     private boolean removeReturnsNull = false;
     private boolean replicated;
     private boolean persisted;
@@ -1259,6 +1260,38 @@ public final class ChronicleMapBuilder<K, V> implements
 
     boolean putReturnsNull() {
         return putReturnsNull;
+    }
+
+    /**
+     * Configures if the maps created by this {@code ChronicleMapBuilder} should reuse the supplied value
+     * to return the previous mapped values on {@link ChronicleMap#putIfAbsent(Object, Object)
+     * ChornicleMap.putIfAbsent(key, value)} calls. <b>It is important to note that if a mapped value is present
+     * for the supplied key, the supplied value will be overridden. </b>
+     * <p>
+     * {@link Map#putIfAbsent(Object, Object) Map.putIfAbsent()} returns the previous value, functionality
+     * which is rarely used but fairly cheap for simple in-process, on-heap implementations like
+     * {@link HashMap}. But an off-heap collection has to create a new object and deserialize
+     * the data from off-heap memory. A collection hiding remote queries over the network should
+     * send the value back in addition to that. It's expensive for something you probably don't use.
+     * <p>
+     * This is a <a href="#jvm-configurations">JVM-level configuration</a>.
+     * <p>
+     * By default, {@code ChronicleMap} conforms the general {@code Map} contract and returns the
+     * previous mapped value on {@code putIfAbsent()} calls and does not change the supplied value.
+     *
+     * @param putIfAbsentUsingValue {@code true} if you want {@link ChronicleMap#putIfAbsent(Object, Object)
+     *                       ChronicleMap.putIfAbsent()} to not return the value that was replaced but
+     *                       instead return {@code null}
+     * @return this builder back
+     * @see #putReturnsNull(boolean)
+     */
+    public ChronicleMapBuilder<K, V> putIfAbsentUsingValue(final boolean putIfAbsentUsingValue) {
+        this.putIfAbsentUsingValue = putIfAbsentUsingValue;
+        return this;
+    }
+
+    boolean putIfAbsentUsingValue() {
+        return putIfAbsentUsingValue;
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/map/issue/PutIfAbsentNoGarbageTest.java
+++ b/src/test/java/net/openhft/chronicle/map/issue/PutIfAbsentNoGarbageTest.java
@@ -1,0 +1,68 @@
+package net.openhft.chronicle.map.issue;
+
+
+import net.openhft.chronicle.core.values.LongValue;
+import net.openhft.chronicle.core.values.StringValue;
+import net.openhft.chronicle.map.ChronicleMap;
+import net.openhft.chronicle.map.ChronicleMapBuilder;
+import net.openhft.chronicle.values.Values;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class PutIfAbsentNoGarbageTest {
+
+    static ChronicleMap<Long, LongValue> newShmLongLongValueUsing(int size, boolean putIfAbsentUsingValue) throws IOException {
+        return ChronicleMapBuilder.simpleMapOf(Long.class, LongValue.class)
+                .entries(size).putIfAbsentUsingValue(putIfAbsentUsingValue).create();
+    }
+
+    @Test
+    public void testPutIfAbsentUsingValue() throws IOException, Throwable {
+        try (ChronicleMap<Long, LongValue> map = newShmLongLongValueUsing(10, true)) {
+            Long k = 1L;
+
+            LongValue v1 = Values.newHeapInstance(LongValue.class);
+            v1.setValue(1L);
+
+            LongValue v2 = Values.newHeapInstance(LongValue.class);
+            v2.setValue(1L);
+
+            LongValue r = map.putIfAbsent(k, v1);
+            Assertions.assertNull(r);
+            Assertions.assertTrue(map.containsKey(k));
+
+            LongValue s = map.putIfAbsent(k, v2);
+            Assertions.assertTrue(map.containsKey(k));
+            Assertions.assertEquals(s, v1);
+            Assertions.assertSame(v2, s, "should be same object");
+        }
+    }
+
+    @Test
+    public void testPutIfAbsentDefault() throws IOException, Throwable {
+        try (ChronicleMap<Long, LongValue> map = newShmLongLongValueUsing(10, false)) {
+            Long k = 1L;
+
+            LongValue v1 = Values.newHeapInstance(LongValue.class);
+            v1.setValue(1L);
+
+            LongValue v2 = Values.newHeapInstance(LongValue.class);
+            v2.setValue(1L);
+
+            LongValue r = map.putIfAbsent(k, v1);
+            Assertions.assertNull(r);
+            Assertions.assertTrue(map.containsKey(k));
+
+            LongValue s = map.putIfAbsent(k, v2);
+            Assertions.assertTrue(map.containsKey(k));
+            Assertions.assertEquals(s, v1);
+            Assertions.assertNotSame(v2, s, "should be same object");
+        }
+    }
+
+
+}


### PR DESCRIPTION
Add an option for putIfAbsent to return null.
The initial implementation copies the putReturnsNull behaviour of always returning null. However, putIfAbsent is different in that it returns the current value if it exists and does not use the new value.