### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"

--- a/benchmark/src/main/java/net/openhft/chronicle/map/perf/MapJLBHTest.java
+++ b/benchmark/src/main/java/net/openhft/chronicle/map/perf/MapJLBHTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.perf;
 

--- a/benchmark/src/main/java/net/openhft/chronicle/map/perf/MapStress.java
+++ b/benchmark/src/main/java/net/openhft/chronicle/map/perf/MapStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.perf;
 

--- a/benchmark/src/main/java/net/openhft/chronicle/map/perf/NonPersistedMapJLBHTest.java
+++ b/benchmark/src/main/java/net/openhft/chronicle/map/perf/NonPersistedMapJLBHTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.perf;
 

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <description>Chronicle-Map</description>
     <packaging>bundle</packaging>
     <properties>
+        <license.year>2013-2026</license.year>
         <zero.cost.assertions>disabled</zero.cost.assertions>
         <sonar.organization>openhft</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/net/openhft/chronicle/hash/AbstractData.java
+++ b/src/main/java/net/openhft/chronicle/hash/AbstractData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/Beta.java
+++ b/src/main/java/net/openhft/chronicle/hash/Beta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChecksumEntry.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChecksumEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleFileLockException.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleFileLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilderPrivateAPI.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilderPrivateAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashClosedException.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashClosedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashCorruption.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashCorruption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashRecoveryFailedException.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashRecoveryFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/Data.java
+++ b/src/main/java/net/openhft/chronicle/hash/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ExternalHashQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/ExternalHashQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/HashAbsentEntry.java
+++ b/src/main/java/net/openhft/chronicle/hash/HashAbsentEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/HashContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/HashContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/HashEntry.java
+++ b/src/main/java/net/openhft/chronicle/hash/HashEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/HashQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/HashQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/HashSegmentContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/HashSegmentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/ReplicatedHashSegmentContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/ReplicatedHashSegmentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/SegmentLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/SegmentLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/VanillaGlobalMutableState.java
+++ b/src/main/java/net/openhft/chronicle/hash/VanillaGlobalMutableState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/BigSegmentHeader.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/BigSegmentHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashCloseOnExitHook.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashCloseOnExitHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashResources.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/CompactOffHeapLinearHashTable.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/CompactOffHeapLinearHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/ContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/HashSplitting.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/HashSplitting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/InMemoryChronicleHashResources.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/InMemoryChronicleHashResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/IntCompactOffHeapLinearHashTable.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/IntCompactOffHeapLinearHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/InternalMapFileAnalyzer.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/InternalMapFileAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/LocalLockState.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/LocalLockState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/LongCompactOffHeapLinearHashTable.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/LongCompactOffHeapLinearHashTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/MemoryResource.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/MemoryResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/PersistedChronicleHashResources.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/PersistedChronicleHashResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/SegmentHeader.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/SegmentHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/SizePrefixedBlob.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/SizePrefixedBlob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/TierCountersArea.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/TierCountersArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHashHolder.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHashHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/EntryKeyBytesData.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/EntryKeyBytesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/InputKeyBytesData.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/InputKeyBytesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/Alloc.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/Alloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/AllocatedChunks.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/AllocatedChunks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/ChecksumHashing.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/ChecksumHashing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/ChecksumStrategy.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/ChecksumStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashEntryChecksumStrategy.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashEntryChecksumStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashEntryStages.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashEntryStages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashLookupPos.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashLookupPos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashLookupSearch.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/HashLookupSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/InputKeyHashCode.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/InputKeyHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/KeyHashCode.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/KeyHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/LocksInterface.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/LocksInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/NoChecksumStrategy.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/NoChecksumStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/ReadLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/ReadLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/SegmentStages.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/SegmentStages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/UpdateLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/UpdateLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/WriteLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/WriteLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/Chaining.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/Chaining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/ChainingInterface.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/ChainingInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/CheckOnEachPublicOperation.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/CheckOnEachPublicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/KeyBytesInterop.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/KeyBytesInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/LogHolder.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/LogHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/OwnerThreadHolder.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/OwnerThreadHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/ThreadLocalState.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/ThreadLocalState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.hash;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/HashSegmentIteration.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/HashSegmentIteration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/IterationAlloc.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/IterationAlloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/IterationKeyHashCode.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/IterationKeyHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/IterationSegmentStages.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/IterationSegmentStages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/SegmentsRecovery.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/SegmentsRecovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/TierRecovery.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/iter/TierRecovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/query/HashQuery.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/query/HashQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/query/KeySearch.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/query/KeySearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/query/QueryAlloc.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/query/QueryAlloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/query/QueryHashLookupSearch.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/query/QueryHashLookupSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/query/QuerySegmentStages.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/query/QuerySegmentStages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/query/SearchAllocatedChunks.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/query/SearchAllocatedChunks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/replication/ReplicableEntryDelegating.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/replication/ReplicableEntryDelegating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.stage.replication;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/BuildVersion.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/BuildVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/CanonicalRandomAccessFiles.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/CanonicalRandomAccessFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/CharSequences.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/CharSequences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/Cleaner.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/Cleaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/CleanerUtils.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/CleanerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/FileIOUtils.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/FileIOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/Objects.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/Objects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/Throwables.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/Throwables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/jna/PosixFallocate.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/jna/PosixFallocate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util.jna;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/ContinuedFraction.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/ContinuedFraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util.math;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Gamma.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Gamma.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util.math;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/PoissonDistribution.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/PoissonDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util.math;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util.math;
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * All classes in this package are copied from Apache Commons Math 3.5

--- a/src/main/java/net/openhft/chronicle/hash/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/hash/locks/InterProcessDeadLockException.java
+++ b/src/main/java/net/openhft/chronicle/hash/locks/InterProcessDeadLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.locks;
 

--- a/src/main/java/net/openhft/chronicle/hash/locks/InterProcessLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/locks/InterProcessLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.locks;
 

--- a/src/main/java/net/openhft/chronicle/hash/locks/InterProcessReadWriteUpdateLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/locks/InterProcessReadWriteUpdateLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.locks;
 

--- a/src/main/java/net/openhft/chronicle/hash/locks/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/locks/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains abstractions of <i>inter-process</i> locks, used in Chronicle Map.

--- a/src/main/java/net/openhft/chronicle/hash/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains common interfaces and utilities for {@link net.openhft.chronicle.map.ChronicleMap

--- a/src/main/java/net/openhft/chronicle/hash/replication/DefaultEventualConsistencyStrategy.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/DefaultEventualConsistencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.replication;
 

--- a/src/main/java/net/openhft/chronicle/hash/replication/RemoteOperationContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/RemoteOperationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.replication;
 

--- a/src/main/java/net/openhft/chronicle/hash/replication/ReplicableEntry.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/ReplicableEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.replication;
 

--- a/src/main/java/net/openhft/chronicle/hash/replication/TimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/TimeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.replication;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/BytesReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/BytesReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/BytesWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/BytesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/DataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/DataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/ListMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/ListMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/MapMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/MapMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SetMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SetMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SizeMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SizeMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SizedWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SizedWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/StatefulCopyable.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/StatefulCopyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/AbstractCharSequenceUtf8DataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/AbstractCharSequenceUtf8DataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/BooleanMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/BooleanMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteArrayDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteArrayDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteArraySizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteArraySizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferSizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferSizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteableSizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ByteableSizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesAsSizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesAsSizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesMarshallableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesMarshallableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesMarshallableReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesMarshallableReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesMarshallableReaderWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesMarshallableReaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesSizedMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/BytesSizedMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/CachingCreatingMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/CachingCreatingMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceBytesReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceBytesReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceBytesWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceBytesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceSizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceSizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceUtf8DataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/CharSequenceUtf8DataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/CommonMarshallableReaderWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/CommonMarshallableReaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ConstantSizeMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ConstantSizeMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/DefaultElasticBytes.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/DefaultElasticBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/DoubleDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/DoubleDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/DoubleMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/DoubleMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/EnumMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/EnumMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ExternalBytesMarshallableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ExternalBytesMarshallableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ExternalizableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ExternalizableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ExternalizableReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ExternalizableReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/InstanceCreatingMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/InstanceCreatingMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/IntegerDataAccess_3_13.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/IntegerDataAccess_3_13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/IntegerMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/IntegerMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/LongDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/LongDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/LongMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/LongMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/MarshallableReaderWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/MarshallableReaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/NotReusingSizedMarshallableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/NotReusingSizedMarshallableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializableReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializableReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializationBuilder.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/SizedMarshallableDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/SizedMarshallableDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/StopBitSizeMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/StopBitSizeMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringBuilderSizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringBuilderSizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringBuilderUtf8DataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringBuilderUtf8DataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringBytesReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringBytesReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringSizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringSizedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringUtf8DataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/StringUtf8DataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/TypedMarshallableReaderWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/TypedMarshallableReaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ValueDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ValueDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/ValueReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/ValueReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * The package contains many classes, implementing interfaces from the parent {@code

--- a/src/main/java/net/openhft/chronicle/hash/serialization/package-info.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains interfaces for serializing objects between Java heap and {@link

--- a/src/main/java/net/openhft/chronicle/map/AbstractChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/AbstractChronicleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ChronicleHashCorruptionImpl.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleHashCorruptionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilderPrivateAPI.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilderPrivateAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapEntrySet.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapIterator.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/DefaultSpi.java
+++ b/src/main/java/net/openhft/chronicle/map/DefaultSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/DefaultValueProvider.java
+++ b/src/main/java/net/openhft/chronicle/map/DefaultValueProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ExternalMapQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/ExternalMapQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/FindByName.java
+++ b/src/main/java/net/openhft/chronicle/map/FindByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
+++ b/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapAbsentEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/MapAbsentEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapClosable.java
+++ b/src/main/java/net/openhft/chronicle/map/MapClosable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapContext.java
+++ b/src/main/java/net/openhft/chronicle/map/MapContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapDiagnostics.java
+++ b/src/main/java/net/openhft/chronicle/map/MapDiagnostics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/MapEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapEntryOperations.java
+++ b/src/main/java/net/openhft/chronicle/map/MapEntryOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapFileAnalyzer.java
+++ b/src/main/java/net/openhft/chronicle/map/MapFileAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapMethods.java
+++ b/src/main/java/net/openhft/chronicle/map/MapMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapMethodsSupport.java
+++ b/src/main/java/net/openhft/chronicle/map/MapMethodsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/MapQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/MapSegmentContext.java
+++ b/src/main/java/net/openhft/chronicle/map/MapSegmentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
+++ b/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/Replica.java
+++ b/src/main/java/net/openhft/chronicle/map/Replica.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedGlobalMutableStateV2.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedGlobalMutableStateV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/ReturnValue.java
+++ b/src/main/java/net/openhft/chronicle/map/ReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/SelectedSelectionKeySet.java
+++ b/src/main/java/net/openhft/chronicle/map/SelectedSelectionKeySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/WriteThroughEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/WriteThroughEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/CompilationAnchor.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/CompilationAnchor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/CompiledMapIterationContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/CompiledMapIterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/CompiledMapQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/CompiledMapQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/CompiledReplicatedMapIterationContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/CompiledReplicatedMapIterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/CompiledReplicatedMapQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/CompiledReplicatedMapQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/IterationContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/IterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/MapIterationContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/MapIterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/MapQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/MapQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/NullReturnValue.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/NullReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/QueryContextInterface.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/QueryContextInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/ReplicatedChronicleMapHolder.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/ReplicatedChronicleMapHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/ReplicatedIterationContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/ReplicatedIterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/ReplicatedMapIterationContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/ReplicatedMapIterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/ReplicatedMapQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/ReplicatedMapQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/VanillaChronicleMapHolder.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/VanillaChronicleMapHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/package-info.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/map/impl/ret/InstanceReturnValue.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/ret/InstanceReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.ret;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/ret/UsableReturnValue.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/ret/UsableReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.ret;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/DummyValueZeroData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/DummyValueZeroData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/ZeroBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/ZeroBytesStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/EntryValueBytesData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/EntryValueBytesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/WrappedValueBytesData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/WrappedValueBytesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/instance/WrappedValueInstanceDataHolder.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/instance/WrappedValueInstanceDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright 2012-2018 Chronicle Map Contributors

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/entry/MapEntryStages.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/entry/MapEntryStages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/entry/ReplicatedMapEntryStages.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/entry/ReplicatedMapEntryStages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.entry;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/input/ReplicatedInput.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/input/ReplicatedInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.input;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/iter/IterationCheckOnEachPublicOperation.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/iter/IterationCheckOnEachPublicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/iter/MapSegmentIteration.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/iter/MapSegmentIteration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedMapAbsentDelegatingForIteration.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedMapAbsentDelegatingForIteration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedMapEntryDelegating.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedMapEntryDelegating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedMapSegmentIteration.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedMapSegmentIteration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedTierRecovery.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/iter/ReplicatedTierRecovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.iter;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/DefaultValue.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/DefaultValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/MapEntryOperationsDelegation.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/MapEntryOperationsDelegation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/ReplicatedChronicleMapHolderImpl.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/ReplicatedChronicleMapHolderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/ValueBytesInterop.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/ValueBytesInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/VanillaChronicleMapHolderImpl.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/VanillaChronicleMapHolderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/WrappedValueBytesDataAccess.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/WrappedValueBytesDataAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/WrappedValueInstanceDataHolderAccess.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/WrappedValueInstanceDataHolderAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.map;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/Absent.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/Absent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/AcquireHandle.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/AcquireHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/MapAbsent.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/MapAbsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/MapAndSetContext.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/MapAndSetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/MapQuery.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/MapQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/QueryCheckOnEachPublicOperation.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/QueryCheckOnEachPublicOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/ReplicatedMapAbsent.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/ReplicatedMapAbsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/ReplicatedMapAbsentDelegating.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/ReplicatedMapAbsentDelegating.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/query/ReplicatedMapQuery.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/query/ReplicatedMapQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.query;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/replication/ReplicatedQueryAlloc.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/replication/ReplicatedQueryAlloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.replication;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/replication/ReplicationUpdate.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/replication/ReplicationUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.replication;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/ret/DefaultReturnValue.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/ret/DefaultReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.ret;
 

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/ret/UsingReturnValue.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/ret/UsingReturnValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.impl.stage.ret;
 

--- a/src/main/java/net/openhft/chronicle/map/internal/AnalyticsHolder.java
+++ b/src/main/java/net/openhft/chronicle/map/internal/AnalyticsHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.internal;
 

--- a/src/main/java/net/openhft/chronicle/map/internal/InternalAssertUtil.java
+++ b/src/main/java/net/openhft/chronicle/map/internal/InternalAssertUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.internal;
 

--- a/src/main/java/net/openhft/chronicle/map/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/map/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/map/locks/ChronicleStampedLock.java
+++ b/src/main/java/net/openhft/chronicle/map/locks/ChronicleStampedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/main/java/net/openhft/chronicle/map/locks/ChronicleStampedLockVOInterface.java
+++ b/src/main/java/net/openhft/chronicle/map/locks/ChronicleStampedLockVOInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/main/java/net/openhft/chronicle/map/package-info.java
+++ b/src/main/java/net/openhft/chronicle/map/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains {@link net.openhft.chronicle.map.ChronicleMap} interface, {@code ChronicleMap} context

--- a/src/main/java/net/openhft/chronicle/map/replication/MapRemoteOperations.java
+++ b/src/main/java/net/openhft/chronicle/map/replication/MapRemoteOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.replication;
 

--- a/src/main/java/net/openhft/chronicle/map/replication/MapRemoteQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/replication/MapRemoteQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.replication;
 

--- a/src/main/java/net/openhft/chronicle/map/replication/MapReplicableEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/replication/MapReplicableEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.replication;
 

--- a/src/main/java/net/openhft/chronicle/set/ChronicleSet.java
+++ b/src/main/java/net/openhft/chronicle/set/ChronicleSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilder.java
+++ b/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilderPrivateAPI.java
+++ b/src/main/java/net/openhft/chronicle/set/ChronicleSetBuilderPrivateAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/DummyValue.java
+++ b/src/main/java/net/openhft/chronicle/set/DummyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/DummyValueData.java
+++ b/src/main/java/net/openhft/chronicle/set/DummyValueData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/DummyValueMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/set/DummyValueMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/ExternalSetQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/set/ExternalSetQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetAbsentEntry.java
+++ b/src/main/java/net/openhft/chronicle/set/SetAbsentEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetContext.java
+++ b/src/main/java/net/openhft/chronicle/set/SetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetEntry.java
+++ b/src/main/java/net/openhft/chronicle/set/SetEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetEntryOperations.java
+++ b/src/main/java/net/openhft/chronicle/set/SetEntryOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetFromMap.java
+++ b/src/main/java/net/openhft/chronicle/set/SetFromMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/set/SetQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/SetSegmentContext.java
+++ b/src/main/java/net/openhft/chronicle/set/SetSegmentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/main/java/net/openhft/chronicle/set/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/set/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/set/package-info.java
+++ b/src/main/java/net/openhft/chronicle/set/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * Contains {@link net.openhft.chronicle.set.ChronicleSet} interface, {@code ChronicleSet} context

--- a/src/main/java/net/openhft/chronicle/set/replication/SetRemoteOperations.java
+++ b/src/main/java/net/openhft/chronicle/set/replication/SetRemoteOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set.replication;
 

--- a/src/main/java/net/openhft/chronicle/set/replication/SetRemoteQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/set/replication/SetRemoteQueryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set.replication;
 

--- a/src/main/java/net/openhft/chronicle/set/replication/SetReplicableEntry.java
+++ b/src/main/java/net/openhft/chronicle/set/replication/SetReplicableEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set.replication;
 

--- a/src/main/java/net/openhft/sg/Context.java
+++ b/src/main/java/net/openhft/sg/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.sg;
 

--- a/src/main/java/net/openhft/sg/Stage.java
+++ b/src/main/java/net/openhft/sg/Stage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.sg;
 

--- a/src/main/java/net/openhft/sg/StageRef.java
+++ b/src/main/java/net/openhft/sg/StageRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.sg;
 

--- a/src/main/java/net/openhft/sg/Staged.java
+++ b/src/main/java/net/openhft/sg/Staged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.sg;
 

--- a/src/main/java/net/openhft/xstream/converters/AbstractChronicleMapConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/AbstractChronicleMapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.xstream.converters;
 

--- a/src/main/java/net/openhft/xstream/converters/ByteBufferConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/ByteBufferConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.xstream.converters;
 

--- a/src/main/java/net/openhft/xstream/converters/CharSequenceConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/CharSequenceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.xstream.converters;
 

--- a/src/main/java/net/openhft/xstream/converters/StringBuilderConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/StringBuilderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.xstream.converters;
 

--- a/src/main/java/net/openhft/xstream/converters/ValueConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/ValueConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.xstream.converters;
 

--- a/src/main/java/net/openhft/xstream/converters/VanillaChronicleMapConverter.java
+++ b/src/main/java/net/openhft/xstream/converters/VanillaChronicleMapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.xstream.converters;
 

--- a/src/main/java/net/openhft/xstream/converters/internal/package-info.java
+++ b/src/main/java/net/openhft/xstream/converters/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/test/java/eg/AverageValueSizeTest.java
+++ b/src/test/java/eg/AverageValueSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg;
 

--- a/src/test/java/eg/BigData.java
+++ b/src/test/java/eg/BigData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg;
 

--- a/src/test/java/eg/OffHeapByteArrayExampleTest.java
+++ b/src/test/java/eg/OffHeapByteArrayExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg;
 

--- a/src/test/java/eg/TestInstrumentVOInterface.java
+++ b/src/test/java/eg/TestInstrumentVOInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg;
 

--- a/src/test/java/eg/WordCountTest.java
+++ b/src/test/java/eg/WordCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg;
 

--- a/src/test/java/examples/portfolio/PortfolioAssetInterface.java
+++ b/src/test/java/examples/portfolio/PortfolioAssetInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package examples.portfolio;
 

--- a/src/test/java/examples/portfolio/PortfolioValueAccumulator.java
+++ b/src/test/java/examples/portfolio/PortfolioValueAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package examples.portfolio;
 

--- a/src/test/java/examples/portfolio/PortfolioValueTest.java
+++ b/src/test/java/examples/portfolio/PortfolioValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package examples.portfolio;
 

--- a/src/test/java/net/openhft/chronicle/hash/impl/util/CleanerUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/hash/impl/util/CleanerUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/test/java/net/openhft/chronicle/hash/impl/util/ThrowablesTest.java
+++ b/src/test/java/net/openhft/chronicle/hash/impl/util/ThrowablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.impl.util;
 

--- a/src/test/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/hash/serialization/impl/ByteBufferDataAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/test/java/net/openhft/chronicle/hash/serialization/impl/SerializableDataAccessTest.java
+++ b/src/test/java/net/openhft/chronicle/hash/serialization/impl/SerializableDataAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.hash.serialization.impl;
 

--- a/src/test/java/net/openhft/chronicle/map/AbstractMarshallableKeyValueTest.java
+++ b/src/test/java/net/openhft/chronicle/map/AbstractMarshallableKeyValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/AcquireGetUsingMain.java
+++ b/src/test/java/net/openhft/chronicle/map/AcquireGetUsingMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ArrayTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/AutoResizeTest.java
+++ b/src/test/java/net/openhft/chronicle/map/AutoResizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BasicReplicationTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BasicReplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BiMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BiMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BitUnitTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BitUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BloatFactorTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BloatFactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BooleanValuesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BooleanValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BuildVersionTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BuildVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/BytesMarshallableValueTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BytesMarshallableValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/CHMLatencyTestMain.java
+++ b/src/test/java/net/openhft/chronicle/map/CHMLatencyTestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/CHMTestIterator1.java
+++ b/src/test/java/net/openhft/chronicle/map/CHMTestIterator1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMap3_12IntegerKeyCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMap3_12IntegerKeyCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapEqualsTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapEqualsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapImportExportTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapImportExportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapNameTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapSanityCheckTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapSanityCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ChronicleMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ConstantSizeBySampleTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ConstantSizeBySampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/DataKeyValueTest.java
+++ b/src/test/java/net/openhft/chronicle/map/DataKeyValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/DatasetTrackerIssue61Test.java
+++ b/src/test/java/net/openhft/chronicle/map/DatasetTrackerIssue61Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/DefaultValueTest.java
+++ b/src/test/java/net/openhft/chronicle/map/DefaultValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/DeflatorStringMarshaller.java
+++ b/src/test/java/net/openhft/chronicle/map/DeflatorStringMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/DeletedSearchStateTest.java
+++ b/src/test/java/net/openhft/chronicle/map/DeletedSearchStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/DemoChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/DemoChronicleMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/EntryCountMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/EntryCountMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ExitHookTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ExitHookTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/FileLockUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/map/FileLockUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ForEachSegmentTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ForEachSegmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/GlobalMutableStateTest.java
+++ b/src/test/java/net/openhft/chronicle/map/GlobalMutableStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/GuavaTest.java
+++ b/src/test/java/net/openhft/chronicle/map/GuavaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/HColl423Test.java
+++ b/src/test/java/net/openhft/chronicle/map/HColl423Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Histogram.java
+++ b/src/test/java/net/openhft/chronicle/map/Histogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/HistogramTest.java
+++ b/src/test/java/net/openhft/chronicle/map/HistogramTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/HugeSparseMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/HugeSparseMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/IntValueMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/IntValueMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue110Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue110Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue125Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue125Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue229Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue229Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue354Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue354Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue354bTest.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue354bTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue42Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue42Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue43Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue43Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue58.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue58.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue60Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue60Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue62ChronicleClient.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue62ChronicleClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue62ChronicleServer.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue62ChronicleServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/Issue63Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue63Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/KeySegmentDistributionTest.java
+++ b/src/test/java/net/openhft/chronicle/map/KeySegmentDistributionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/KeySizesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/KeySizesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/LargeEntriesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/LargeEntriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/LargeMapMain.java
+++ b/src/test/java/net/openhft/chronicle/map/LargeMapMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/LataTest.java
+++ b/src/test/java/net/openhft/chronicle/map/LataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ListenersTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ListenersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/LoggingMapEntryOperations.java
+++ b/src/test/java/net/openhft/chronicle/map/LoggingMapEntryOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/LostKeyTest.java
+++ b/src/test/java/net/openhft/chronicle/map/LostKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/MapCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/map/MapCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/MarkTest.java
+++ b/src/test/java/net/openhft/chronicle/map/MarkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/MarshallableReaderWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/map/MarshallableReaderWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/MemoryLeaksTest.java
+++ b/src/test/java/net/openhft/chronicle/map/MemoryLeaksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/MissSizedMapsTest.java
+++ b/src/test/java/net/openhft/chronicle/map/MissSizedMapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/NegativeIntegerKeyTest.java
+++ b/src/test/java/net/openhft/chronicle/map/NegativeIntegerKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/NestedContextsInIterationContextTest.java
+++ b/src/test/java/net/openhft/chronicle/map/NestedContextsInIterationContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/NestedContextsTest.java
+++ b/src/test/java/net/openhft/chronicle/map/NestedContextsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/NoUpperBoundChunksPerEntryTest.java
+++ b/src/test/java/net/openhft/chronicle/map/NoUpperBoundChunksPerEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/OSResizesMain.java
+++ b/src/test/java/net/openhft/chronicle/map/OSResizesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/OverflowAllocationDuringIterationTest.java
+++ b/src/test/java/net/openhft/chronicle/map/OverflowAllocationDuringIterationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/PageLatencyMain.java
+++ b/src/test/java/net/openhft/chronicle/map/PageLatencyMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ProcessInstanceLimiterMain.java
+++ b/src/test/java/net/openhft/chronicle/map/ProcessInstanceLimiterMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/RecoverTest.java
+++ b/src/test/java/net/openhft/chronicle/map/RecoverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/RecursiveRefereneChMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/RecursiveRefereneChMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ReplicatedChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ReplicatedChronicleMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/SerializableTest.java
+++ b/src/test/java/net/openhft/chronicle/map/SerializableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/SimplePersistedMapOverflowTest.java
+++ b/src/test/java/net/openhft/chronicle/map/SimplePersistedMapOverflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/TrickyContextCasesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/TrickyContextCasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ValueAlignmentRelocationTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ValueAlignmentRelocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/ValueInterfaceWithEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ValueInterfaceWithEnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/VeryLargeMapMain.java
+++ b/src/test/java/net/openhft/chronicle/map/VeryLargeMapMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/VinceTest.java
+++ b/src/test/java/net/openhft/chronicle/map/VinceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/WarnOnWindowsTest.java
+++ b/src/test/java/net/openhft/chronicle/map/WarnOnWindowsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/WriteThroughputTest.java
+++ b/src/test/java/net/openhft/chronicle/map/WriteThroughputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/example/DistributedSequenceMain.java
+++ b/src/test/java/net/openhft/chronicle/map/example/DistributedSequenceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.example;
 

--- a/src/test/java/net/openhft/chronicle/map/example/HashQueryContextExamples.java
+++ b/src/test/java/net/openhft/chronicle/map/example/HashQueryContextExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.example;
 

--- a/src/test/java/net/openhft/chronicle/map/example/LotsOfEntriesMain.java
+++ b/src/test/java/net/openhft/chronicle/map/example/LotsOfEntriesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.example;
 

--- a/src/test/java/net/openhft/chronicle/map/example/PointListSerializationTest.java
+++ b/src/test/java/net/openhft/chronicle/map/example/PointListSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.example;
 

--- a/src/test/java/net/openhft/chronicle/map/example/SimpleMapOperationsListeningTest.java
+++ b/src/test/java/net/openhft/chronicle/map/example/SimpleMapOperationsListeningTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.example;
 

--- a/src/test/java/net/openhft/chronicle/map/example/StringArrayExampleTest.java
+++ b/src/test/java/net/openhft/chronicle/map/example/StringArrayExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.example;
 

--- a/src/test/java/net/openhft/chronicle/map/externalizable/ExternalizableTest.java
+++ b/src/test/java/net/openhft/chronicle/map/externalizable/ExternalizableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.externalizable;
 

--- a/src/test/java/net/openhft/chronicle/map/externalizable/SomeClass.java
+++ b/src/test/java/net/openhft/chronicle/map/externalizable/SomeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.externalizable;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/BondVOInterface.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/BondVOInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceArrayBytesMarshaller.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceArrayBytesMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceArraySerializationTest.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceArraySerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceCustomEncodingBytesReader.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceCustomEncodingBytesReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceCustomEncodingBytesWriter.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/CharSequenceCustomEncodingBytesWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/ChecksumEntryTest.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/ChecksumEntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/CustomCharSequenceEncodingTest.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/CustomCharSequenceEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/OpenJDKAndHashMapExamplesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/OpenJDKAndHashMapExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/Point.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/Point.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/PointListSizedMarshaller.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/PointListSizedMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/PointSerializationTest.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/PointSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/ChronicleAcidIsolation.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/ChronicleAcidIsolation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/ChronicleAcidIsolationGovernor.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/ChronicleAcidIsolationGovernor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/exodus/DirtyReadOffender.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/exodus/DirtyReadOffender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.exodus;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/exodus/DirtyReadTolerance.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/exodus/DirtyReadTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.exodus;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/exodus/DirtyReadVictim.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/exodus/DirtyReadVictim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.exodus;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/genesis/DirtyReadOffender.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/genesis/DirtyReadOffender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.genesis;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/genesis/DirtyReadTolerance.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/genesis/DirtyReadTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.genesis;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/genesis/DirtyReadVictim.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/genesis/DirtyReadVictim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.genesis;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/ChronicleStampedLock.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/ChronicleStampedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/ChronicleStampedLockVOInterface.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/ChronicleStampedLockVOInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadIntolerant.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadIntolerant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadOffender.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadOffender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadTolerance.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadVictim.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadVictim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadVictimTest.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/acid/revelations/DirtyReadVictimTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.acid.revelations;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongAddLeft.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongAddLeft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.pingpong_latency;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongAddRight.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongAddRight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.pingpong_latency;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongCASLeft.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongCASLeft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.pingpong_latency;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongCASRight.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongCASRight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.pingpong_latency;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongLockLeft.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongLockLeft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.pingpong_latency;
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongLockRight.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/pingpong_latency/PingPongLockRight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.fromdocs.pingpong_latency;
 

--- a/src/test/java/net/openhft/chronicle/map/ipc/StateMachineData.java
+++ b/src/test/java/net/openhft/chronicle/map/ipc/StateMachineData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.ipc;
 

--- a/src/test/java/net/openhft/chronicle/map/ipc/StateMachineProcessor.java
+++ b/src/test/java/net/openhft/chronicle/map/ipc/StateMachineProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.ipc;
 

--- a/src/test/java/net/openhft/chronicle/map/ipc/StateMachineState.java
+++ b/src/test/java/net/openhft/chronicle/map/ipc/StateMachineState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.ipc;
 

--- a/src/test/java/net/openhft/chronicle/map/ipc/StateMachineTutorial.java
+++ b/src/test/java/net/openhft/chronicle/map/ipc/StateMachineTutorial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.ipc;
 

--- a/src/test/java/net/openhft/chronicle/map/issue/Issue423LockFileRemainsLockedOnWindowsIfBuilderThrowsTest.java
+++ b/src/test/java/net/openhft/chronicle/map/issue/Issue423LockFileRemainsLockedOnWindowsIfBuilderThrowsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.issue;
 

--- a/src/test/java/net/openhft/chronicle/map/issue/ParallelStartupTest.java
+++ b/src/test/java/net/openhft/chronicle/map/issue/ParallelStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.issue;
 

--- a/src/test/java/net/openhft/chronicle/map/issue/PutIfAbsentNoGarbageTest.java
+++ b/src/test/java/net/openhft/chronicle/map/issue/PutIfAbsentNoGarbageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.issue;
 import net.openhft.chronicle.core.values.LongValue;

--- a/src/test/java/net/openhft/chronicle/map/jsr166/JSR166TestCase.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/JSR166TestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.jsr166;
 

--- a/src/test/java/net/openhft/chronicle/map/jsr166/map/ChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/map/ChronicleMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.jsr166.map;
 

--- a/src/test/java/net/openhft/chronicle/map/jsr166/map/LoopHelpers.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/map/LoopHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.jsr166.map;
 

--- a/src/test/java/net/openhft/chronicle/map/jsr166/map/MapCheck.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/map/MapCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.jsr166.map;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/BondVOInterface.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/BondVOInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadIntolerant.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadIntolerant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadIntolerant_ReaderReader_Test.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadIntolerant_ReaderReader_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffenderIPCTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffenderIPCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffenderTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender_ReaderWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender_ReaderWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender_WriterReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender_WriterReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender_WriterWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadOffender_WriterWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadTolerance.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadVictim.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadVictim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadVictimIPCTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadVictimIPCTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/DirtyReadVictimTest.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/DirtyReadVictimTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/ReaderToo.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/ReaderToo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/locks/WriterToo.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/WriterToo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.locks;
 

--- a/src/test/java/net/openhft/chronicle/map/utility/ProcessInstanceLimiter.java
+++ b/src/test/java/net/openhft/chronicle/map/utility/ProcessInstanceLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map.utility;
 

--- a/src/test/java/net/openhft/chronicle/set/Builder.java
+++ b/src/test/java/net/openhft/chronicle/set/Builder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/test/java/net/openhft/chronicle/set/ChronicleSetBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/set/ChronicleSetBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/test/java/net/openhft/chronicle/set/Issue24ChronicleSetTest.java
+++ b/src/test/java/net/openhft/chronicle/set/Issue24ChronicleSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/test/java/net/openhft/chronicle/set/Issue3Test.java
+++ b/src/test/java/net/openhft/chronicle/set/Issue3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/test/java/net/openhft/chronicle/set/SetEntryOperationsTest.java
+++ b/src/test/java/net/openhft/chronicle/set/SetEntryOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.set;
 

--- a/src/test/java/net/openhft/lang/values/ArrayTest.java
+++ b/src/test/java/net/openhft/lang/values/ArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.lang.values;
 

--- a/src/test/java/net/openhft/lang/values/DoubleArray.java
+++ b/src/test/java/net/openhft/lang/values/DoubleArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.lang.values;
 

--- a/src/test/java/net/openhft/lang/values/DoubleArrayTest.java
+++ b/src/test/java/net/openhft/lang/values/DoubleArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.lang.values;
 

--- a/src/test/java/net/openhft/lang/values/MovingAverageArray.java
+++ b/src/test/java/net/openhft/lang/values/MovingAverageArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.lang.values;
 

--- a/src/test/java/net/openhft/lang/values/MovingAverageCompact.java
+++ b/src/test/java/net/openhft/lang/values/MovingAverageCompact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.lang.values;
 

--- a/system.properties
+++ b/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 #
 
 # Tracing if resources are closed/released correctly.


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, "Chronicle Map Contributors", etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in `pom.xml` so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the one-line `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)