### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/CM_Compatibility_and_Versioning.adoc
+++ b/docs/CM_Compatibility_and_Versioning.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 === Public API
 
-The *public API* comprises public classes that are included in http://www.javadoc.io/doc/net.openhft/chronicle-map/[Javadoc].
+The *public API* comprises public classes that are included in https://www.javadoc.io/doc/net.openhft/chronicle-map/[Javadoc].
 
 NOTE: Other public classes are not subject to the following rules; they may be changed in any way, or even removed.
 

--- a/docs/CM_Download.adoc
+++ b/docs/CM_Download.adoc
@@ -44,7 +44,7 @@ for versioning e.g.
 </dependencyManagement>
 ```
 
-Click here to get the http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22net.openhft%22%20AND%20a%3A%22chronicle-bom%22[Latest Version Number].
+Click here to get the https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22net.openhft%22%20AND%20a%3A%22chronicle-bom%22[Latest Version Number].
 
 Alternatively, Chronicle Map can be included directly:
 
@@ -56,7 +56,7 @@ Alternatively, Chronicle Map can be included directly:
 </dependency>
 ```
 
-Click here to get the http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22net.openhft%22%20AND%20a%3A%22chronicle-map%22[Latest Version Number].
+Click here to get the https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22net.openhft%22%20AND%20a%3A%22chronicle-map%22[Latest Version Number].
 
 == Maven Snapshot Download
 

--- a/docs/CM_Features.adoc
+++ b/docs/CM_Features.adoc
@@ -88,7 +88,7 @@ See https://github.com/OpenHFT/Chronicle-Map/blob/master/spec[Chronicle Map data
 There are no secondary indexes.
 - A https://en.wikipedia.org/wiki/Multimap[multimap].
 Using a Chronicle Map collection as a multimap is technically possible, but often leads to problems.
-See http://stackoverflow.com/a/36486525/648955[StackOverflow answer] for details.
+See https://stackoverflow.com/a/36486525/648955[StackOverflow answer] for details.
 Developing a proper multimap, using Chronicle Map's design principles is possible.
 
 Please contact us at mailto:sales@chronicle.software[sales@chronicle.software] if you would consider sponsoring such development.
@@ -129,7 +129,7 @@ NOTE: For access to commercially available features please contact mailto:sales@
 
 - https://github.com/OpenHFT/Chronicle-Map/issues[Issues]
 - https://groups.google.com/forum/#!forum/chronicle-map[Chronicle Map mailing list]
-- http://stackoverflow.com/tags/chronicle-map[Stackoverflow]
+- https://stackoverflow.com/tags/chronicle-map[Stackoverflow]
 
 '''
 

--- a/docs/CM_Tutorial.adoc
+++ b/docs/CM_Tutorial.adoc
@@ -85,7 +85,7 @@ When no processes access the file, it could be moved to another location in the 
 It could even run on different operating systems.
 When opened from another location you will observe the same data.
 
-If you don't need the Chronicle Map instance to survive a server restart (that is, you don't need persistence to disk; only multi-process access), mount the file on http://en.wikipedia.org/wiki/Tmpfs[tmpfs].
+If you don't need the Chronicle Map instance to survive a server restart (that is, you don't need persistence to disk; only multi-process access), mount the file on https://en.wikipedia.org/wiki/Tmpfs[tmpfs].
 For example, on `Linux` it is as easy as placing your file in `/dev/shm` directory.
 
 == Configure entries
@@ -96,7 +96,7 @@ Try to configure the entries so that the created Chronicle Map is going to serve
 You should not put additional margin over the actual target number of entries.
 This bad practice was popularized by `new HashMap(capacity)` and `new HashSet(capacity)` constructors, which accept capacity, that should be multiplied by load factor to obtain the actual maximum expected number of entries in the container. `ChronicleMap` and `ChronicleSet` do not have a notion of a load factor.
 
-See `ChronicleMapBuilder#entries()` in http://www.javadoc.io/doc/net.openhft/chronicle-map/[Javadocs] for more information.
+See `ChronicleMapBuilder#entries()` in https://www.javadoc.io/doc/net.openhft/chronicle-map/[Javadocs] for more information.
 
 Once a `ChronicleMap` instance is created, its configurations are sealed and cannot be changed using the `ChronicleMapBuilder` instance.
 
@@ -173,8 +173,8 @@ The key, or value type, of `ChronicleMap<K, V>` could be:
 
 - Types with best possible out-of-the-box support:
 ** Any https://github.com/OpenHFT/Chronicle-Values[value interface]
-** Any class implementing http://openhft.github.io/Chronicle-Bytes/apidocs/net/openhft/chronicle/bytes/Byteable.html[`Byteable`] interface from https://github.com/OpenHFT/Chronicle-Bytes[Chronicle Bytes].
-** Any class implementing http://openhft.github.io/Chronicle-Bytes/apidocs/net/openhft/chronicle/bytes/BytesMarshallable.html[`BytesMarshallable`].
+** Any class implementing https://openhft.github.io/Chronicle-Bytes/apidocs/net/openhft/chronicle/bytes/Byteable.html[`Byteable`] interface from https://github.com/OpenHFT/Chronicle-Bytes[Chronicle Bytes].
+** Any class implementing https://openhft.github.io/Chronicle-Bytes/apidocs/net/openhft/chronicle/bytes/BytesMarshallable.html[`BytesMarshallable`].
 interface from Chronicle Bytes.
 The implementation class should have a public no-arg constructor.
 ** `byte[]` and `ByteBuffer`
@@ -652,7 +652,7 @@ Entry checksums are computed automatically when an entry is inserted into a Chro
 For example, `map.put()`,
 `map.replace()`, `map.compute()`, `mapEntry.doReplaceValue()`.
 See the `MapEntry` interface in
-http://www.javadoc.io/doc/net.openhft/chronicle-map/[Javadocs].
+https://www.javadoc.io/doc/net.openhft/chronicle-map/[Javadocs].
 If you update values directly, bypassing Chronicle Map logic, keeping the entry checksum up-to-date is also your responsibility.
 
 It is strongly recommended to update off-heap memory of values directly only within a context, and update or write lock held.

--- a/spec/3_1-header-fields.md
+++ b/spec/3_1-header-fields.md
@@ -223,7 +223,7 @@ The size of segment tiers in this Chronicle Map, in bytes. A positive 64-bit val
 > 64. The `tierSize` is a multiple of 64 (i. e. it spans integral number of cache lines). The
 > optional extra cache line is added, when the `tierSize` is too round, and there are too many
 > segments, in order to break collisions of tiers' start addresses by L1 cache banks. See e. g.
-> [this post](http://danluu.com/3c-conflict/) for more information on this effect.
+> [this post](https://danluu.com/3c-conflict/) for more information on this effect.
 
 ##### `maxExtraTiers`
 

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/EntryKeyBytesData.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/EntryKeyBytesData.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/InputKeyBytesData.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/data/bytes/InputKeyBytesData.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/ContinuedFraction.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/ContinuedFraction.java
@@ -10,7 +10,7 @@ package net.openhft.chronicle.hash.impl.util.math;
  *
  * References:
  * <ul>
- * <li><a href="http://mathworld.wolfram.com/ContinuedFraction.html">
+ * <li><a href="https://mathworld.wolfram.com/ContinuedFraction.html">
  * Continued Fraction</a></li>
  * </ul>
  */
@@ -44,12 +44,12 @@ abstract class ContinuedFraction {
      * <ul>
      * <li>
      * I. J. Thompson,  A. R. Barnett. "Coulomb and Bessel Functions of Complex Arguments and Order."
-     * <a target="_blank" href="http://www.fresco.org.uk/papers/Thompson-JCP64p490.pdf">
-     * http://www.fresco.org.uk/papers/Thompson-JCP64p490.pdf</a>
+     * <a target="_blank" href="https://www.fresco.org.uk/papers/Thompson-JCP64p490.pdf">
+     * https://www.fresco.org.uk/papers/Thompson-JCP64p490.pdf</a>
      * </li>
      * </ul>
      * <b>Note:</b> the implementation uses the terms a<sub>i</sub> and b<sub>i</sub> as defined in
-     * <a href="http://mathworld.wolfram.com/ContinuedFraction.html">Continued Fraction @ MathWorld</a>.
+     * <a href="https://mathworld.wolfram.com/ContinuedFraction.html">Continued Fraction @ MathWorld</a>.
      *
      * @param x             the evaluation point.
      * @param epsilon       maximum error allowed.

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Gamma.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Gamma.java
@@ -11,19 +11,19 @@ package net.openhft.chronicle.hash.impl.util.math;
  * Implementation of {@link #invGamma1pm1(double)} and
  * {@link #logGamma1p(double)} is based on the algorithms described in
  * <ul>
- * <li><a href="http://dx.doi.org/10.1145/22721.23109">Didonato and Morris
+ * <li><a href="https://dx.doi.org/10.1145/22721.23109">Didonato and Morris
  * (1986)</a>, <em>Computation of the Incomplete Gamma Function Ratios and
  * their Inverse</em>, TOMS 12(4), 377-393,</li>
- * <li><a href="http://dx.doi.org/10.1145/131766.131776">Didonato and Morris
+ * <li><a href="https://dx.doi.org/10.1145/131766.131776">Didonato and Morris
  * (1992)</a>, <em>Algorithm 708: Significant Digit Computation of the
  * Incomplete Beta Function Ratios</em>, TOMS 18(3), 360-373,</li>
  * </ul>
  * and implemented in the
- * <a href="http://www.dtic.mil/docs/citations/ADA476840">NSWC Library of Mathematical Functions</a>,
+ * <a href="https://www.dtic.mil/docs/citations/ADA476840">NSWC Library of Mathematical Functions</a>,
  * available
- * <a href="http://www.ualberta.ca/CNS/RESEARCH/Software/NumericalNSWC/site.html">here</a>.
+ * <a href="https://www.ualberta.ca/CNS/RESEARCH/Software/NumericalNSWC/site.html">here</a>.
  * This library is "approved for public release", and the
- * <a href="http://www.dtic.mil/dtic/pdf/announcements/CopyrightGuidance.pdf">Copyright guidance</a>
+ * <a href="https://www.dtic.mil/dtic/pdf/announcements/CopyrightGuidance.pdf">Copyright guidance</a>
  * indicates that unless otherwise stated in the code, all FORTRAN functions in
  * this library are license free. Since no such notice appears in the code these
  * functions can safely be ported to Commons-Math.
@@ -263,11 +263,11 @@ class Gamma {
      * implementation in the <em>NSWC Library of Mathematics Subroutines</em>,
      * {@code DGAMLN}. For x &gt; 8, the implementation is based on
      * <ul>
-     * <li><a href="http://mathworld.wolfram.com/GammaFunction.html">Gamma
+     * <li><a href="https://mathworld.wolfram.com/GammaFunction.html">Gamma
      * Function</a>, equation (28).</li>
-     * <li><a href="http://mathworld.wolfram.com/LanczosApproximation.html">
+     * <li><a href="https://mathworld.wolfram.com/LanczosApproximation.html">
      * Lanczos Approximation</a>, equations (1) through (5).</li>
-     * <li><a href="http://my.fit.edu/~gabdo/gamma.txt">Paul Godfrey, A note on
+     * <li><a href="https://my.fit.edu/~gabdo/gamma.txt">Paul Godfrey, A note on
      * the computation of the convergent Lanczos complex Gamma
      * approximation</a></li>
      * </ul>
@@ -308,15 +308,15 @@ class Gamma {
      * The implementation of this method is based on:
      * <ul>
      * <li>
-     * <a href="http://mathworld.wolfram.com/RegularizedGammaFunction.html">
+     * <a href="https://mathworld.wolfram.com/RegularizedGammaFunction.html">
      * Regularized Gamma Function</a>, equation (1)
      * </li>
      * <li>
-     * <a href="http://mathworld.wolfram.com/IncompleteGammaFunction.html">
+     * <a href="https://mathworld.wolfram.com/IncompleteGammaFunction.html">
      * Incomplete Gamma Function</a>, equation (4).
      * </li>
      * <li>
-     * <a href="http://mathworld.wolfram.com/ConfluentHypergeometricFunctionoftheFirstKind.html">
+     * <a href="https://mathworld.wolfram.com/ConfluentHypergeometricFunctionoftheFirstKind.html">
      * Confluent Hypergeometric Function of the First Kind</a>, equation (1).
      * </li>
      * </ul>
@@ -377,11 +377,11 @@ class Gamma {
      * The implementation of this method is based on:
      * <ul>
      * <li>
-     * <a href="http://mathworld.wolfram.com/RegularizedGammaFunction.html">
+     * <a href="https://mathworld.wolfram.com/RegularizedGammaFunction.html">
      * Regularized Gamma Function</a>, equation (1).
      * </li>
      * <li>
-     * <a href="http://functions.wolfram.com/GammaBetaErf/GammaRegularized/10/0003/">
+     * <a href="https://functions.wolfram.com/GammaBetaErf/GammaRegularized/10/0003/">
      * Regularized incomplete gamma function: Continued fraction representations
      * (formula 06.08.10.0003)</a>
      * </li>
@@ -443,9 +443,9 @@ class Gamma {
      *
      * @param x Argument.
      * @return The Lanczos approximation.
-     * @see <a href="http://mathworld.wolfram.com/LanczosApproximation.html">Lanczos Approximation</a>
+     * @see <a href="https://mathworld.wolfram.com/LanczosApproximation.html">Lanczos Approximation</a>
      * equations (1) through (5), and Paul Godfrey's
-     * <a href="http://my.fit.edu/~gabdo/gamma.txt">Note on the computation
+     * <a href="https://my.fit.edu/~gabdo/gamma.txt">Note on the computation
      * of the convergent Lanczos complex Gamma approximation</a>
      * @since 3.1
      */

--- a/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/util/math/Precision.java
@@ -42,7 +42,7 @@ class Precision {
      * floating point numbers are considered equal.
      * <p>
      * Adapted from <a
-     * href="http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/">
+     * href="https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/">
      * Bruce Dawson</a>
      *
      * @param x       first value

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -82,7 +82,7 @@ import static net.openhft.chronicle.hash.replication.TimeProvider.currentTime;
  * node with the smallest identifier wins. </p>
  * <p>This a one of the basic building blocks needed to implement a fully-functioning Chronicle Map
  * cluster, such as that provided in
- * <a href="http://chronicle.software/products/chronicle-map/">Chronicle Map Enterprise</a>.
+ * <a href="https://chronicle.software/products/chronicle-map/">Chronicle Map Enterprise</a>.
  *
  * @param <K> the entries key type
  * @param <V> the entries value type

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/DummyValueZeroData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/DummyValueZeroData.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/ZeroBytesStore.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/ZeroBytesStore.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/EntryValueBytesData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/EntryValueBytesData.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/WrappedValueBytesData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/bytes/WrappedValueBytesData.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/instance/WrappedValueInstanceDataHolder.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/instance/WrappedValueInstanceDataHolder.java
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/net/openhft/chronicle/map/BooleanValuesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/BooleanValuesTest.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class BooleanValuesTest {
 
     /**
-     * see issue <a href="http://stackoverflow.com/questions/26219313/strange-npe-from-chronicle-map-toy-code">here</a>
+     * see issue <a href="https://stackoverflow.com/questions/26219313/strange-npe-from-chronicle-map-toy-code">here</a>
      */
     @Test
     public void testTestBooleanValues() throws IOException, InterruptedException {

--- a/src/test/java/net/openhft/chronicle/map/ExitHookTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ExitHookTest.java
@@ -105,7 +105,7 @@ public class ExitHookTest {
                 .entries(1);
     }
 
-    // http://stackoverflow.com/a/33171840/648955
+    // https://stackoverflow.com/a/33171840/648955
     public static long getPidOfProcess(Process p) {
         Number pid = Jvm.getValue(p, "pid");
         return pid.longValue();
@@ -226,7 +226,7 @@ public class ExitHookTest {
         }
     }
 
-    // http://stackoverflow.com/a/7835467/648955
+    // https://stackoverflow.com/a/7835467/648955
     @SuppressWarnings("deprecation")
     private void interruptProcess(long pidOfProcess) throws IOException {
         Runtime.getRuntime().exec("kill -SIGINT " + pidOfProcess);

--- a/src/test/java/net/openhft/chronicle/map/ReplicatedChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ReplicatedChronicleMapTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.*;
 /*
  * Originally written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/publicdomain/zero/1.0/
+ * https://creativecommons.org/publicdomain/zero/1.0/
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd. Then modified by the Open HFT team.
  */

--- a/src/test/java/net/openhft/chronicle/map/jsr166/map/ChronicleMapTest.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/map/ChronicleMapTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.*;
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/publicdomain/zero/1.0/
+ * https://creativecommons.org/publicdomain/zero/1.0/
  * Other contributors include Andrew Wright, Jeffrey Hayes,
  * Pat Fisher, Mike Judd.
  */

--- a/src/test/java/net/openhft/chronicle/map/jsr166/map/LoopHelpers.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/map/LoopHelpers.java
@@ -6,7 +6,7 @@ package net.openhft.chronicle.map.jsr166.map;
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/publicdomain/zero/1.0/
+ * https://creativecommons.org/publicdomain/zero/1.0/
  */
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23,7 +23,7 @@ class LoopHelpers {
 
     /**
      * generates 32 bit pseudo-random numbers.
-     * Adapted from <a href="http://www.snippets.org">...</a>
+     * Adapted from <a href="https://www.snippets.org">...</a>
      */
     public static int compute1(int x) {
         int lo = 16807 * (x & 0xFFFF);

--- a/src/test/java/net/openhft/chronicle/map/jsr166/map/MapCheck.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/map/MapCheck.java
@@ -12,7 +12,7 @@ import java.util.*;
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/publicdomain/zero/1.0/
+ * https://creativecommons.org/publicdomain/zero/1.0/
  */
 
 /**


### PR DESCRIPTION
## Summary
- Upgrades `http://` to `https://` in documentation files (.adoc, .md, LICENSE, NOTICE, AGENTS) and Java comment lines.
- Skips XML namespace identifiers (`xmlns=`, `xsi:schemaLocation=`) and non-comment Java source where a URL might be a literal value.
- Mechanical change, no code behaviour affected.

## Test plan
- [ ] Visual diff - only protocol `http` -> `https` changes.
- [ ] Spot-check a few upgraded links still resolve.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)