### PR TITLE
docs: close the space in "i. e." and "e. g."

### DIFF
--- a/docs/CM_Tutorial.adoc
+++ b/docs/CM_Tutorial.adoc
@@ -641,7 +641,7 @@ Theoretically, there is still about a one-in-a-billion chance that after entry c
 
 By default, entry checksums are:
 
-- **`ON`** if the Chronicle Map is persisted to disk (i. e. created via
+- **`ON`** if the Chronicle Map is persisted to disk (i.e. created via
 `createPersistedTo()` method)
 - **`OFF`** if the Chronicle Map is purely in-memory.
 

--- a/spec/1-design-goals.md
+++ b/spec/1-design-goals.md
@@ -5,7 +5,7 @@
  - Chronicle Map optionally persists to a *single file* via the memory-mapping facility, present in
  Windows and POSIX-compatible operating systems (`mmap`). The file shouldn't necessarily materialize
  on disk. It's OK for Chronicle Map if the file resides on a memory-mounted file system. The whole
- Chronicle Map state is contained in the file contents i. e. it is possible to move, copy or send
+ Chronicle Map state is contained in the file contents i.e. it is possible to move, copy or send
  the file to another machine, access it and observe exactly the same Chronicle Map state. Chronicle
  Map doesn't use the metadata of the file.
  - Chronicle Map supports fully-featured concurrent access from multiple processes, mapping the same
@@ -35,7 +35,7 @@ Chronicle Map implementation. It might be an OS thread or a "greener" thread.
 
 #### CPU
 
- - The CPU supports atomic 64-bit compare-and-swap operations with aligned memory, i. e. if several
+ - The CPU supports atomic 64-bit compare-and-swap operations with aligned memory, i.e. if several
  threads, possibly belonging to different processes, try to perform compare-and-swap operation on
  the same 4-byte block, at most one thread will succeed and all the rest will fail.
  - Aligned 32-bit or 64-bit writes are atomic, that means either all 4(8) bytes are written to
@@ -61,10 +61,10 @@ The two above points are true for CPUs with x86 and x86_64 architectures.
 
  - The memory-mapping implementation doesn't corrupt mapped files, even if operating system
  execution was interrupted in any way (black out, virtual machine crash, etc.) It means Chronicle
- Map expects some memory might be "stale", i. e. the values written shortly before operating system
+ Map expects some memory might be "stale", i.e. the values written shortly before operating system
  failure might not be persisted, but it doesn't expect to read values that have never been written
  to the memory.
- - Writes to the disk are at least 4 or 8 bytes atomic, i. e. either aligned 4- or 8-byte blocks
+ - Writes to the disk are at least 4 or 8 bytes atomic, i.e. either aligned 4- or 8-byte blocks
  are fully written to the disk, or not written at all (in case of power loss, virtual machine crash,
  etc.).
 
@@ -74,9 +74,9 @@ The two above points are true for CPUs with x86 and x86_64 architectures.
 Chronicle Map *doesn't* assume anything specific about how memory if flushed to the disk:
 
  - The order in which memory is flushed (up or down by addresses, random, concurrent, etc.).
- - The maximum timeout dirty memory might not be flushed to the disk, i. e. Chronicle Map assumes
+ - The maximum timeout dirty memory might not be flushed to the disk, i.e. Chronicle Map assumes
  some memory might remain dirty forever.
- - The maximum fraction of dirty memory not written to the disk, i. e. Chronicle Map assumes that
+ - The maximum fraction of dirty memory not written to the disk, i.e. Chronicle Map assumes that
  *all* the mapped memory might be dirty.
 
 #### File locking
@@ -89,7 +89,7 @@ https://en.wikipedia.org/wiki/File_locking).
 If the above assumptions are met, Chronicle Map aims to satisfy the following guarantees:
 
  - Single-key and multi-key accesses and updates to the Chronicle Map (multi-key updates could span
- several Chronicle Map stores) are concurrently isolated, i. e. accesses involving a certain key
+ several Chronicle Map stores) are concurrently isolated, i.e. accesses involving a certain key
  are totally ordered across accessing threads and processes. All updates made to the entry during
  the previous update are visible during the subsequent accesses. After a multi-key update,
  a subsequent multi-key query involving a subset of the updated keys (and possibly some more keys)
@@ -114,7 +114,7 @@ Therefore, *some entries updated shortly before the failure could be lost.*
 The ultimate goal of Chronicle Map design is efficiency:
 
  - If the number of entries in Chronicle Map is much greater than the number of accessor CPUs, it
- scales (i. e. adding the last CPU still adds to the total throughput) up to the total number of
+ scales (i.e. adding the last CPU still adds to the total throughput) up to the total number of
  CPUs present in the system.
  - Chronicle Map is a low-latency key-value store, meaning that for any particular percentile (90%,
  99%, 99.9% etc.) the latency of Chronicle Map operations should be the best or among the best
@@ -139,7 +139,7 @@ guarantees, but it shouldn't be expected to be similarly efficient.
 ## Non-goals
 
  - Alphabetical ordering of the keys (sorted keys).
- - Durability. There are ways to make Chronicle Map look like a durable key-value store, e. g.
+ - Durability. There are ways to make Chronicle Map look like a durable key-value store, e.g.
  to call `msync` after each operation. However, if required, it would be better to use a data store
  designed for durability.
 

--- a/spec/2-design-overview.md
+++ b/spec/2-design-overview.md
@@ -11,7 +11,7 @@ performing a query to a Chronicle Map:
  2. Identify the segment that should hold the key, based on the hash code.
  3. Acquire the segment lock on the needed level.
  4. Search for the entry with the queried key in the segment.
- 5. Perform the actual query operation on the entry, if the entry is found (e. g. read the value,
+ 5. Perform the actual query operation on the entry, if the entry is found (e.g. read the value,
  update the value, etc.), or insert the entry, if the queried key was absent in the segment, and
  insertion of a previously absent entry is implied by the logic of the query being performed.
  6. Release the segment lock.
@@ -22,7 +22,7 @@ For multi-key queries,
  2. Acquire the locks of all the involved segments. Within each involved Chronicle Map store,
  acquire the segment locks in the order of their segments.
 
- > Acquiring segment locks always in the same order is needed to avoid dead-locks, e. g. when the
+ > Acquiring segment locks always in the same order is needed to avoid dead-locks, e.g. when the
  > first thread acquires the lock of the segment #1 and then tries to acquire the lock of the
  > segment #2, and the second thread does the opposite: locks the segment #2, then tries to lock the
  > segment #1.
@@ -132,7 +132,7 @@ level.
 
 ### Tier chaining
 
-If a segment tier is filled up, i. e. on some entry insertion request entry space fails to allocate
+If a segment tier is filled up, i.e. on some entry insertion request entry space fails to allocate
 a memory block sufficient to place the new entry, *a whole new segment tier is allocated and chained
 after the previous tier.* All tiers, either first in their segments or chained, are identical.
 

--- a/spec/3-memory-layout.md
+++ b/spec/3-memory-layout.md
@@ -15,7 +15,7 @@ one big continuous block of memory. Its structure, from lower addresses to highe
  3. [The global mutable state](#global-mutable-state).
  4. [Segment header alignment](#segment-headers-alignment")
  The alignment to the next page boundary by addresses (page size of the current memory mapping),
- if a new Chronicle Map is created, if an existing one (i. e. persisted) is loaded, the alignment
+ if a new Chronicle Map is created, if an existing one (i.e. persisted) is loaded, the alignment
  is read from the global mutable state (specifically this field of the global mutable state is
  actually immutable, once written).
 
@@ -45,9 +45,9 @@ The structure of this area is described in the [Size Prefixed Blob](
 https://github.com/OpenHFT/RFC/blob/master/Size-Prefixed-Blob/Size-Prefixed-Blob-0.1.md)
 specification. The first 8 bytes contains the hash value of bytes sequence from 9th byte to the end
 of this size-prefixed blob, computed by [xxHash](https://github.com/Cyan4973/xxHash/) algorithm
-(XXH64 version). The "message" is marked as user data (i. e. the user/meta data bit is set to 0).
+(XXH64 version). The "message" is marked as user data (i.e. the user/meta data bit is set to 0).
 
-The self-bootstrapping header itself (i. e. the "message" of the size-prefixed blob) is encoded in
+The self-bootstrapping header itself (i.e. the "message" of the size-prefixed blob) is encoded in
 Text Wire format. Once created, this header is never changed. It contains all configurations,
 immutable for Chronicle Map during the data store lifetime: number of segments, various sizes,
 offsets, etc. See the specification of the fields on [Map Header Fields](3_1-header-fields.md) page.
@@ -75,7 +75,7 @@ The global mutable state is 33 bytes long.
 
  ##### Tier index
  *Tier index* is *1-counted* from the beginning of the main segments area, and counting continues in
- the extra tier bulks, i. e. the first tier of the segment #0 has *tier index* 1, the first tier of
+ the extra tier bulks, i.e. the first tier of the segment #0 has *tier index* 1, the first tier of
  the segment #1 has tier index 2, ... the first tier of the last segment (it's index is
  [`actualSegments`](3_1-header-fields.md#actualsegments) &minus; 1) has tier index `actualSegments`,
  the first tier of the first extra tier bulk has tier index `actualSegments` + 1, etc. Tier indexes
@@ -121,7 +121,7 @@ multiples of `segmentHeaderSize`. Each segment header is 32 bytes long. `segment
  range of continuous free chunks in the [free list](#free-list) is started from this index, rather
  than 0. This field is updated on each entry allocation and deletion in the first tier of the
  segment, if the smallest index of a free chunk is changed. When all chunks in the entry space are
- allocated (i. e. the current tier becomes *full*), the value of this field is changed to
+ allocated (i.e. the current tier becomes *full*), the value of this field is changed to
  [`actualChunksPerSegmentTier`](3_1-header-fields.md#actualchunkspersegmenttier) (an impossible
  chunk index, which varies from 0 to `actualChunksPerSegmentTier` &minus; 1).
  4. Bytes 16..23 - the [index](#tier-index) of the next segment tier, chained after the first tier
@@ -176,11 +176,11 @@ In [`tierHashLookupKeyBits`](3_1-header-fields.md#tierhashlookupkeybits) lower b
 a *hash lookup key* is stored. It is a part of a Chronicle Map's key hash code, extracted by the
 [`hashSplitting`](3_1-header-fields.md#hashsplitting) algorithm. In addition, if the `hashSplitting`
 extracts the part of the hash code of 0, a hash lookup key of all set `tierHashLookupKeyBits` bits
-(i. e. `(1 << tierHashLookupKeyBits) - 1`) is used instead, to avoid the full hash lookup slot to
+(i.e. `(1 << tierHashLookupKeyBits) - 1`) is used instead, to avoid the full hash lookup slot to
 look like an empty slot, if the *hash lookup value* is also 0.
 
 In [`tierHashLookupValueBits`](3_1-header-fields.md#tierhashlookupvaluebits) bits, following after
-the lower key bits (i. e. bits from `tierHashLookupKeyBits`-th to `tierHashLookupKeyBits +
+the lower key bits (i.e. bits from `tierHashLookupKeyBits`-th to `tierHashLookupKeyBits +
 tierHashLookupValueBits - 1`-th, inclusive) of a slot value a *hash lookup value* is stored. It is
 an index of the first chunk of the range of chunks (possibly only a single chunk) in the entry space
 of this segment tier, in which a Chronicle Map's entry is stored.
@@ -201,10 +201,10 @@ tier.
 
 The segment tier counters structure is 64 bytes long:
 
- 1. Bytes 0..7 - for tiers from extra tier bulks (i. e. tiers that are not first in chains of
+ 1. Bytes 0..7 - for tiers from extra tier bulks (i.e. tiers that are not first in chains of
  their segments), this field is the [index](#tier-index) of the next segment tier, chained after
  this segment tier. I. e. this field value in the second tier in the chain - to the third tier in
- the chain, and so on. For tiers from the main segment area (i. e. first in chains of their
+ the chain, and so on. For tiers from the main segment area (i.e. first in chains of their
  segments), this field is unused, the 4th field of the [segment header
  structure](#segment-header-structure) is used instead. This field and the 4th field in the segment
  header structure have the same semantics, with the only difference that this field serves chained
@@ -215,7 +215,7 @@ The segment tier counters structure is 64 bytes long:
  means there is no chained segment tier in this segment yet after the current tier, in other words,
  the current tier is the last in the chain for the current segment.
 
- When the tier is in the *free* state, i. e. allocated in the extra tier bulk, but not yet assigned
+ When the tier is in the *free* state, i.e. allocated in the extra tier bulk, but not yet assigned
  to some segment, the value of this field is the index of the next *free* tier. The index of the
  first free tier is pointed by the 3rd field of the [global mutable state](#global-mutable-state).
 
@@ -226,15 +226,15 @@ The segment tier counters structure is 64 bytes long:
 
  2. Bytes 8..15 - the [index](#tier-index) of the previous segment tier, chained before this segment
  tier. It is a 64-bit value, stored in the little-endian order. In tiers in the main segments area,
- i. e. first tiers in segments' chains, this field has value 0, this means there is no previous
+ i.e. first tiers in segments' chains, this field has value 0, this means there is no previous
  tiers in chains.
 
  This field together with the previous field form a doubly-linked list of chained tiers within each
  segment.
 
- 3. Bytes 16..23 - for tiers from extra tier bulks (i. e. tiers that are not first in chains of
+ 3. Bytes 16..23 - for tiers from extra tier bulks (i.e. tiers that are not first in chains of
  their segments), this field is the smallest index of a chunk in the entry space of this tier,
- that could possibly be free. For tiers from the main segment area (i. e. first in chains of their
+ that could possibly be free. For tiers from the main segment area (i.e. first in chains of their
  segments), this field is unused, the 3rd field of the [segment header structure
  ](#segment-header-structure) is used instead. This field and the 3rd field in the segment header
  structure have the same semantics, with the only difference that this field serves chained tiers
@@ -254,7 +254,7 @@ The segment tier counters structure is 64 bytes long:
  value of this field is 0 (because they are first in chains of their segments), in the tiers which
  are second in chains of their segments the value of this field is 1, in third tiers - 2, and so on.
 
- 6. Bytes 32..35 - for tiers that from extra tier bulks (i. e. not first in chains of their segments
+ 6. Bytes 32..35 - for tiers that from extra tier bulks (i.e. not first in chains of their segments
  ), this field is the number of entries, stored in the tier. In tiers from the main segments area
  this field is unused, the 2nd field of the [segment header structure](#segment-header-structure) is
  used instead. Like the 3rd field of the tier counters structure, this field and the 2nd field in
@@ -299,7 +299,7 @@ The entry space starts with an internal offset of [`tierEntrySpaceInnerOffset`
 each chunk of [`chunkSize`](3_1-header-fields.md#chunksize) bytes.
 
 A chunk is the minimum allocation unit. A single or several continuous chunks are used to store the
-Chronicle Map's entries. These ranges doesn't intersect, i. e. each chunk is used to store at most
+Chronicle Map's entries. These ranges doesn't intersect, i.e. each chunk is used to store at most
 one entry.
 
 ##### Stored entry structure

--- a/spec/3_1-header-fields.md
+++ b/spec/3_1-header-fields.md
@@ -8,16 +8,16 @@ following fields:
 
 ##### `dataFileVersion`
 
-A `String` containing the version of the reference Java implementation, e. g. `"3.5.0-beta"`.
+A `String` containing the version of the reference Java implementation, e.g. `"3.5.0-beta"`.
 
 ##### `keyClass`
 
-The `Class` of the Chronicle Map's keys, e. g. `!type int32` (corresponds to `java.lang.Integer`).
+The `Class` of the Chronicle Map's keys, e.g. `!type int32` (corresponds to `java.lang.Integer`).
 
 ##### `keySizeMarshaller`
 
 The marshaller for the Chronicle Map's key sizes, an instance of
-`net.openhft.chronicle.hash.serialization.SizeMarshaller`, e. g.
+`net.openhft.chronicle.hash.serialization.SizeMarshaller`, e.g.
 ```yaml
 !net.openhft.chronicle.hash.serialization.impl.ConstantSizeMarshaller {
     constantSize: 4
@@ -37,7 +37,7 @@ The marshaller for the Chronicle Map's key sizes, an instance of
 ##### `keyReader`
 
 The reader for the Chronicle Map's keys, an instance of
-`net.openhft.chronicle.hash.serialization.SizedReader`, e. g.
+`net.openhft.chronicle.hash.serialization.SizedReader`, e.g.
 ```yaml
 !net.openhft.chronicle.hash.serialization.impl.IntegerMarshaller {
 }
@@ -46,7 +46,7 @@ The reader for the Chronicle Map's keys, an instance of
 ##### `keyDataAccess`
 
 The data access strategy for the Chronicle Map's keys, an instance of
-`net.openhft.chronicle.hash.serialization.DataAccess`, e. g.
+`net.openhft.chronicle.hash.serialization.DataAccess`, e.g.
 ```yaml
 !net.openhft.chronicle.hash.serialization.impl.NotReusingSizedMarshallableDataAccess {
     tClass: !type int32,
@@ -68,14 +68,14 @@ them. A boolean value, `true` or `false`.
 ##### `actualSegments`
 
 The number of [segments](2-design-overview.md#logic) in this Chronicle Map. A positive signed
-32-bit value, e. g. `16`.
+32-bit value, e.g. `16`.
 
 ##### `hashSplitting`
 
 The algorithm for choosing both the segment for a key based on it's 64-bit hash code, and
 the data to play the role of key in the segment tier's [hash lookups](
 2-design-overview.md#segment-tier). An instance of `net.openhft.chronicle.hash.impl.HashSplitting`,
-e. g.
+e.g.
 ```yaml
 !net.openhft.chronicle.hash.impl.HashSplitting$ForPowerOf2Segments {
     bits: 4
@@ -101,7 +101,7 @@ e. g.
 ##### `chunkSize`
 
 The size in bytes of the allocation unit (*chunk*) of the segment tier's [entry space](
-2-design-overview.md#segment-tier). A positive 64-bit value, e. g. `4`.
+2-design-overview.md#segment-tier). A positive 64-bit value, e.g. `4`.
 
 > Unless both keys and values are constant sized, the reference Java implementation by default
 > chooses a chunk size which is a power of 2, so that an average-sized entry spans from 4 to 8
@@ -110,16 +110,16 @@ The size in bytes of the allocation unit (*chunk*) of the segment tier's [entry 
 ##### `maxChunksPerEntry`
 
 The maximum number of chunks a single entry could span. A positive signed 32-bit value, with upper
-bound of the `actualChunksPerSegmentTier` value, e. g. `3303`.
+bound of the `actualChunksPerSegmentTier` value, e.g. `3303`.
 
 #####`actualChunksPerSegmentTier`
 
-The size of the segment tier's entry space area, in chunks. A positive 64-bit value, e. g. `3303`.
+The size of the segment tier's entry space area, in chunks. A positive 64-bit value, e.g. `3303`.
 
 ##### `segmentHeaderSize`
 
 The number of bytes between starts of the segment headers. A 32-bit value, greater or equal to 32,
-e. g. `192`.
+e.g. `192`.
 
 > Segment headers take only 32 bytes, the rest space between segment headers is alignment aimed to
 > reduce false sharing. The maximum reasonable `segmentHeaderSize` value for modern Intel CPUs is
@@ -129,17 +129,17 @@ e. g. `192`.
 ##### `tierHashLookupValueBits`
 
 The number of bits of the tier hash lookup's slots, used to store the index of the first chunk
-allocated for the Chronicle Map's entry. A 32-bit value in [1, 63] range, e. g. `12`.
+allocated for the Chronicle Map's entry. A 32-bit value in [1, 63] range, e.g. `12`.
 
 > In the reference Java implementation the number of value bits is as little as enough to encode any
-> chunk index, i. e.
+> chunk index, i.e.
 > log(2, nextPowerOf2([`actualChunksPerSegmentTier`](#actualchunkspersegmenttier)))
 
 ##### `tierHashLookupKeyBits`
 
 The number of bits of the tier hash lookup's slots, used to store parts of the Chronicle Map key's
 hash codes, playing the role of key in hash lookup tables. The part of hash codes is extracted by
-the [`hashSplitting`](#hashsplitting) algorithm. A 32-bit value is [1, 63] range, e. g. `20`.
+the [`hashSplitting`](#hashsplitting) algorithm. A 32-bit value is [1, 63] range, e.g. `20`.
 
 ##### `tierHashLookupSlotSize`
 
@@ -148,12 +148,12 @@ The size of the tier hash lookup's slots, in bytes. A 32-bit value, `4` or `8`. 
 
 ##### `tierHashLookupCapacity`
 
-The number of slots in the hash lookups. A positive 64-bit value, a power of 2, e. g. `2048`.
+The number of slots in the hash lookups. A positive 64-bit value, a power of 2, e.g. `2048`.
 
 ##### `maxEntriesPerHashLookup`
 
-The maximum number of entries, allowed to be stored in a segment tier, i. e. number of slots taken
-in a hash lookup. A positive 64-bit value, e. g. `1638`.
+The maximum number of entries, allowed to be stored in a segment tier, i.e. number of slots taken
+in a hash lookup. A positive 64-bit value, e.g. `1638`.
 
 > In the reference Java implementation, `maxEntriesPerHashLookup` is chosen as
 > `tierHashLookupCapacity` * 0.8. When linear-probing hash table's load factor exceeds 0.8, chain
@@ -163,42 +163,42 @@ in a hash lookup. A positive 64-bit value, e. g. `1638`.
 
 The size of hash lookups in bytes. A positive 64-bit value, equals to [`tierHashLookupInnerSize`
 ](#tierhashlookupinnersize) * [`tierHashLookupSlotSize`](#tierhashlookupslotsize). A positive
-64-bit value, e. g. `8192`.
+64-bit value, e.g. `8192`.
 
 ##### `tierHashLookupOuterSize`
 
-The size of hash lookups + alignment, in bytes. A positive 64-bit value, e. g. `8192`.
+The size of hash lookups + alignment, in bytes. A positive 64-bit value, e.g. `8192`.
 
 > In the reference Java implementation, `tierHashLookupOuterSize` equals to the
 > [`tierHashLookupInnerSize`](#tierhashlookupinnersize) value, rounded up to the next multiple of 64
-> (i. e. a cache line boundary).
+> (i.e. a cache line boundary).
 
 ##### `tierFreeListInnerSize`
 
 The size segment tiers' *free lists* (indexes of free chunks in entry spaces), in bytes. A positive
-64-bit value, e. g. `416`.
+64-bit value, e.g. `416`.
 
 > In the reference Java implementation, `tierFreeListInnerSize` equals to
 > the [`actualChunksPerSegmentTier`](#actualchunkspersegmenttier) value, rounded up to the next
-> multiple of 64, then divided by 8, i. e. the dimension of this value is bytes, and it is a
+> multiple of 64, then divided by 8, i.e. the dimension of this value is bytes, and it is a
 > multiple of 8.
 
 ##### `tierFreeListOuterSize`
 
-The size of free lists + alignment, in bytes. A positive 64-bit value, e. g. `448`.
+The size of free lists + alignment, in bytes. A positive 64-bit value, e.g. `448`.
 
 > In the reference Java implementation, `tierFreeListOuterSize` equals to the
 > [`tierFreeListInnerSize`](#tierfreelistinnersize) value, rounded up to the next multiple of 64
-> (i. e. a cache line boundary).
+> (i.e. a cache line boundary).
 
 ##### `tierEntrySpaceInnerSize`
 
-The size of segment tiers' entry spaces, in bytes. A positive 64-bit value, e. g. `13212`.
+The size of segment tiers' entry spaces, in bytes. A positive 64-bit value, e.g. `13212`.
 
 ##### `tierEntrySpaceInnerOffset`
 
 The offset in entry spaces from the start to the offset of the first chunk. A non-negative 32-bit
-value, e. g. `0`.
+value, e.g. `0`.
 
 > This offset is non-zero, when both keys and values are constant sized, and the value size is not a
 > multiple of the [`alignment`](#alignment), then the first chunk of the entry space is *misaligned*
@@ -206,29 +206,29 @@ value, e. g. `0`.
 
 ##### `tierEntrySpaceOuterSize`
 
-The size of segment tiers' entry spaces + alignment, in bytes. A positive 64-bit value, e. g.
+The size of segment tiers' entry spaces + alignment, in bytes. A positive 64-bit value, e.g.
 `13248`.
 
 > In the reference Java implementation, `tierEntrySpaceOuterSize` equals to the
 > [`tierEntrySpaceInnerSize`](#tierentryspaceinnersize) value, rounded up to the next multiple of 64
-> (i. e. a cache line boundary).
+> (i.e. a cache line boundary).
 
 ##### `tierSize`
 
-The size of segment tiers in this Chronicle Map, in bytes. A positive 64-bit value, e. g. `21952`.
+The size of segment tiers in this Chronicle Map, in bytes. A positive 64-bit value, e.g. `21952`.
 
 > In the reference Java implementation, `tierSize` equals to [`tierHashLookupOuterSize`
 > ](#tierhashlookupoutersize) + 64 (*tier counters area* size) + [`tierFreeListOuterSize`
 > ](#tierfreelistoutersize) + [`tierEntrySpaceOuterSize`](#tierentryspaceoutersize) + (optionally)
-> 64. The `tierSize` is a multiple of 64 (i. e. it spans integral number of cache lines). The
+> 64. The `tierSize` is a multiple of 64 (i.e. it spans integral number of cache lines). The
 > optional extra cache line is added, when the `tierSize` is too round, and there are too many
-> segments, in order to break collisions of tiers' start addresses by L1 cache banks. See e. g.
+> segments, in order to break collisions of tiers' start addresses by L1 cache banks. See e.g.
 > [this post](http://danluu.com/3c-conflict/) for more information on this effect.
 
 ##### `maxExtraTiers`
 
 The maximum number of extra tiers could be allocated, before the Chronicle Map is full and rejects
-new insertion requests. A non-negative 64-bit value, e. g. `16`.
+new insertion requests. A non-negative 64-bit value, e.g. `16`.
 
 > In the reference Java implementation, `maxExtraTiers` defaults to the [`actualSegments`
 > ](#actualsegments). I. e. the Chronicle Map could nearly double the expected size, before it
@@ -237,7 +237,7 @@ new insertion requests. A non-negative 64-bit value, e. g. `16`.
 ##### `tierBulkSizeInBytes`
 
 The size in bytes of a *tier bulk*, a unit of memory allocation, when extra tiers are needed. A
-positive 64-bit value, e. g. `43904`.
+positive 64-bit value, e.g. `43904`.
 
 > In the reference Java implementation, `tierBulkSizeInBytes` equals to
 > [`tierBulkInnerOffsetToTiers`](#tierbulkinneroffsettotiers) + [`tiersInBulk`](#tiersinbulk) *
@@ -246,11 +246,11 @@ positive 64-bit value, e. g. `43904`.
 ##### `tierBulkInnerOffsetToTiers`
 
 The offset from tier bulks' starts to the address of the first tier within a bulk, in bytes. This
-space is used as metadata of a tier bulk. A non-negative 64-bit value, e. g. `0`.
+space is used as metadata of a tier bulk. A non-negative 64-bit value, e.g. `0`.
 
 ##### `tiersInBulk`
 
-The number of tiers in the tier bulks. A positive 64-bit value, e. g. `2`.
+The number of tiers in the tier bulks. A positive 64-bit value, e.g. `2`.
 
 ##### `log2TiersInBulk`
 
@@ -258,12 +258,12 @@ The value of this field equals to log(2, [`tiersInBulk`](#tiersinbulk)).
 
 ##### `valueClass`
 
-The `Class` of the Chronicle Map's values, e. g. `!type CharSequence`.
+The `Class` of the Chronicle Map's values, e.g. `!type CharSequence`.
 
 ##### `valueSizeMarshaller`
 
 The marshaller for the Chronicle Map's value sizes, an instance of
-`net.openhft.chronicle.hash.serialization.SizeMarshaller`, e. g.
+`net.openhft.chronicle.hash.serialization.SizeMarshaller`, e.g.
 ```yaml
 !net.openhft.chronicle.hash.serialization.impl.StopBitSizeMarshaller {
 }
@@ -274,7 +274,7 @@ The marshaller for the Chronicle Map's value sizes, an instance of
 ##### `valueReader`
 
 The reader for the Chronicle Map's values, an instance of
-`net.openhft.chronicle.hash.serialization.SizedReader`, e. g.
+`net.openhft.chronicle.hash.serialization.SizedReader`, e.g.
 ```yaml
 !net.openhft.chronicle.hash.serialization.impl.CharSequenceSizedReader {
 }
@@ -283,7 +283,7 @@ The reader for the Chronicle Map's values, an instance of
 ##### `valueDataAccess`
 
 The data access strategy for the Chronicle Map's values, an instance of
-`net.openhft.chronicle.hash.serialization.DataAccess`, e. g.
+`net.openhft.chronicle.hash.serialization.DataAccess`, e.g.
 ```yaml
 !net.openhft.chronicle.hash.serialization.impl.SizedMarshallableDataAccess {
     tClass: !type CharSequence,
@@ -302,7 +302,7 @@ A flag denoting if both keys and values of the Chronicle Map are constant sized.
 ##### `alignment`
 
 The alignment (in bytes) of the values of this Chronicle Maps, by addresses, when residing the entry
-spaces. A positive, 32-bit, power of 2 value, e. g. `1`.
+spaces. A positive, 32-bit, power of 2 value, e.g. `1`.
 
 ##### `worstAlignment`
 
@@ -311,7 +311,7 @@ alignment waste might vary, if the [`chunkSize`](#chunksize) is not a multiple o
 [`alignment`](#alignment), and/or due to amount of memory before value in the [stored entry
 structure](3-memory-layout.md#stored-entry-structure) might vary.
 
-A non-negative 32-bit value, e. g. `0`.
+A non-negative 32-bit value, e.g. `0`.
 
 > ## The reference Java implementation
 >

--- a/spec/3_2-lock-structure.md
+++ b/spec/3_2-lock-structure.md
@@ -86,8 +86,8 @@ procedure starts, the procedure must fail.
 
  1. (Optional step) Read the count word of the lock state.
  2. (Optional step) If the count word is non-zero, the procedure fails.
- 3. Perform a CAS operation on the count word of the lock state, comparing 0 (i. e. the operation
- fails, if any bit of the count word is non-zero) and swapping with 0x80000000, i. e. a count word
+ 3. Perform a CAS operation on the count word of the lock state, comparing 0 (i.e. the operation
+ fails, if any bit of the count word is non-zero) and swapping with 0x80000000, i.e. a count word
  with the write lock flag set, the update lock flag not set, and the read lock count of zero. The
  result of the CAS operation is the result of the procedure.
 
@@ -112,16 +112,16 @@ procedure and call one depending on the context.
 
 ## Release write lock, or write to update lock downgrade, or write to read lock downgrade
 
-Perform a CAS operation on the count word of the lock state, comparing 0x80000000 (i. e. a count
+Perform a CAS operation on the count word of the lock state, comparing 0x80000000 (i.e. a count
 word with the write lock flag set) and swapping with 0 (in case of releasing write lock), or
 0x40000000 (in case of write to update lock downgrade), or 1 (in case of write to read lock
 downgrade). The result of the CAS operation is the result of the procedure.
 
 ## Try upgrade to write lock
 
-Perform a CAS operation on the count word of the lock state, comparing 0x40000000 (i. e. a count
+Perform a CAS operation on the count word of the lock state, comparing 0x40000000 (i.e. a count
 word with the update lock flag set, the write lock flag not set, the read lock count of zero) and
-swapping with 0x80000000, i. e. a count word with the write lock flag set, the update lock flag not
+swapping with 0x80000000, i.e. a count word with the write lock flag set, the update lock flag not
 set, and the read lock count of zero. The result of the CAS operation is the result of the
 procedure.
 

--- a/spec/4-hashing-algorithms.md
+++ b/spec/4-hashing-algorithms.md
@@ -21,12 +21,12 @@ The primary checksum is a 64-bit value.
 
 If the 2nd field of the [stored entry structure
 ](3-memory-layout.md#stored-entry-structure) ends at the same address, as the 6th field of the same
-structure starts, i. e. the value size is 0, and the size itself is stored using 0 bytes, and there
+structure starts, i.e. the value size is 0, and the size itself is stored using 0 bytes, and there
 is no value alignment, the key hash code *is* the primary checksum.
 
 Otherwise, the [xxHash](https://github.com/Cyan4973/xxHash/) algorithm (XXH64 version) is applied to
 the memory range between the end of the 2nd field of the stored entry structure and the end of the
-5th field, i. e. between the end of the stored key and the end of the stored value. The resulting
+5th field, i.e. between the end of the stored key and the end of the stored value. The resulting
 hash value is called *payload checksum*.
 
 > xxHash is used to compute the payload checksum instead of CRC32, because the Java implementation

--- a/spec/5-initialization.md
+++ b/spec/5-initialization.md
@@ -11,7 +11,7 @@ This section describes the process of creation of a new Chronicle Map data store
 existing Map, persisted to some file).
 
  1. If the Chronicle Map should be persisted to some file, and this file does not exist, this file
- is created as empty, i. e. with size of 0 bytes.
+ is created as empty, i.e. with size of 0 bytes.
 
  2. If the Chronicle Map should be persisted to some file, and the size of the file is non-zero,
  [wait until the Chronicle Map is ready](#wait-until-chronicle-map-is-ready). Otherwise, acquire
@@ -40,14 +40,14 @@ existing Map, persisted to some file).
 
  If on this step we were waiting until Chronicle Map is ready, then start using Chronicle Map
  normally. If on this step we wrote self-bootstrapping header or the Chronicle Map is not persisted
- to any file (i. e. purely in-memory), continue initialization with following steps:
+ to any file (i.e. purely in-memory), continue initialization with following steps:
 
  3. Zero out the [global mutable state](3-memory-layout.md#global-mutable-state)'s space in the
  file.
  4. Zero out the [segment headers area](3-memory-layout.md#segment-headers-area) in the file.
  5. For each segment tier in the [main segments area](3-memory-layout.md#main-segments-area), zero
  out memory from the beginning of the tier to the start of the [entry space](
- 3-memory-layout.md#entry-space), i. e. zero out this tier's hash lookup, segment tier counters area
+ 3-memory-layout.md#entry-space), i.e. zero out this tier's hash lookup, segment tier counters area
  and free list.
  6. Write the segment headers offset into the 5th field of the global mutable state.
  7. Write the offset to the end of the main segments area into the 6th field of the global mutable
@@ -55,7 +55,7 @@ existing Map, persisted to some file).
  8. If the Chronicle Map is persisted, ensure all data written to the file is flushed to the disk.
  For example on Linux, this could be done with `msync` and `fdatasync` calls, on Windows - with
  `FlushFileBuffers` system call.
- 9. If the Chronicle Map is persisted, write the readiness bit into the header, i. e. the highest
+ 9. If the Chronicle Map is persisted, write the readiness bit into the header, i.e. the highest
  bit of the 32-bit word by offset 8 from the beginning of the file, read and written in the
  little-endian order. Read the [Size Prefix Blob](
  https://github.com/OpenHFT/RFC/blob/master/Size-Prefixed-Blob/Size-Prefixed-Blob-0.1.md)
@@ -67,7 +67,7 @@ existing Map, persisted to some file).
 Check until the readiness bit is set to 0. The readiness bit it the highest bit of 32-bit word by
 offset 8 from the beginning of the Chronicle Map persistence file, read in the little-endian order.
 
-Optionally yield processor resources after failed checks, e. g. make the waiting thread sleep for
+Optionally yield processor resources after failed checks, e.g. make the waiting thread sleep for
 some time. The exact yielding operation (or if it is making the current thread sleeping, the exact
 sleep interval) is unspecified.
 
@@ -105,14 +105,14 @@ by [global mutable state](3-memory-layout.md#global-mutable-state) lock.
  Chronicle Map data store (either the end of the [main segments area](
  3-memory-layout.md#main-segments-area) or the end of the previous extra tier bulk) by the minimum
  memory amount allowed for mapping (a multiple of the native page size), that covers space required
- for the next extra tier bulk, i. e. [`tierBulkSizeInBytes`](
+ for the next extra tier bulk, i.e. [`tierBulkSizeInBytes`](
  3_1-header-fields.md#tierbulksizeinbytes) bytes from the previous end of the Chronicle Map data
  store.
  2. Prepare the extra tier bulk's metadata space, that starts at the beginning of the extra tier
  bulk and spans [`tierBulkInnerOffsetToTiers`](3_1-header-fields.md#tierbulkinneroffsettotiers),
  according to the way how metadata space is actually used. This is unspecified.
  3. For each tier in the extra tier bulk, zero out memory from the beginning of the tier to the
- start of the [entry space](3-memory-layout.md#entry-space), i. e. zero out this tier's hash lookup,
+ start of the [entry space](3-memory-layout.md#entry-space), i.e. zero out this tier's hash lookup,
  segment tier counters area and free list. This step is equivalent to the 5th step of the [Chronicle
  Map creation](#chronicle-map-creation) procedure.
  4. For each (but the last one) tier in the extra tier bulk, write [index of the next tier](

--- a/spec/6-queries.md
+++ b/spec/6-queries.md
@@ -22,7 +22,7 @@ belongs to).
 The *next tier field* of some tier is the 4th field of the [segment header structure](
 3-memory-layout.md#segment-header-structure) (if the tier is the first in the segment it belongs
 to), or the 1st field of the [counters area](3-memory-layout.md#segment-tier-counters-area) (if the
-tier belongs to one of [extra tier bulks](3-memory-layout.md#extra-tier-bulks), i. e. not the first
+tier belongs to one of [extra tier bulks](3-memory-layout.md#extra-tier-bulks), i.e. not the first
 in the segment it belongs to).
 
 ## Key lookup
@@ -75,10 +75,10 @@ in the segment it belongs to).
  If any of two checks is failed during this step, continue with the next step.
 
  6. Compute the next hash lookup slot, by incrementing the current slot index and wrapping around
- [`tierHashLookupCapacity`](3_1-header-fields.md#tierhashlookupcapacity) (i. e. instead of
+ [`tierHashLookupCapacity`](3_1-header-fields.md#tierhashlookupcapacity) (i.e. instead of
  `tierHashLookupCapacity` the slot index becomes 0). Then continue with the 4th step.
 
- 7. If the current tier is the last tier in the chain for the current segment, i. e. the value of
+ 7. If the current tier is the last tier in the chain for the current segment, i.e. the value of
  the [next tier field](#next-tier-field) of the current tier is 0, the lookup operation is failed.
  Otherwise, continue with the next linked tier (as the new current tier) and go to the 3rd step.
 
@@ -168,7 +168,7 @@ in the segment it belongs to).
  this could be deferred in the case of multi-key query, or the lock could be downgraded to the read
  level.
 
- 14. If the current tier is the last tier in the chain for the segment, i. e. the value of the [next
+ 14. If the current tier is the last tier in the chain for the segment, i.e. the value of the [next
  tier field](#next-tier-field) of the current tier is 0, go to the 15th step. Otherwise, continue
  with the next linked tier (as the new current tier) and go to the 5th step.
 
@@ -197,7 +197,7 @@ Steps 4-5 are *in-place* value update. Steps from 6 to the end of the operation 
  > on the write level right away allows not to perform a lock upgrade operation later. On the other
  > hand, if there are frequent concurrent readers, reducing the time when the lock is held on an
  > exclusive level improves concurrency. This is an implementation choice. The reference Java
- > implementation takes the second way, i. e. acquires lock on the update level first, and upgrades
+ > implementation takes the second way, i.e. acquires lock on the update level first, and upgrades
  > to the write level for the least possible time.
 
  Value update is possible only if the lookup operation is *successful*.
@@ -221,7 +221,7 @@ Steps 4-5 are *in-place* value update. Steps from 6 to the end of the operation 
 
  > In-place value update (the following step) is performed on fully exclusive locking level, because
  > concurrent readers could see inconsistent value state, while the update is in progress. If the
- > value could be updated atomically on machine level: e. g. the value is just 4 or 8 bytes long
+ > value could be updated atomically on machine level: e.g. the value is just 4 or 8 bytes long
  > and could be updated by a single ordinary (atomic on x86) memory transfer, implementations
  > may omit acquiring the segment lock on the write level on this step.
 
@@ -281,7 +281,7 @@ Steps 4-5 are *in-place* value update. Steps from 6 to the end of the operation 
  > to work correctly for overlapping memory regions.
 
  14. Copy the part of the already existing entry (located on the first step of this operation)
- before the 3rd field, i. e. stored key size and the key itself, to the entry space of the current
+ before the 3rd field, i.e. stored key size and the key itself, to the entry space of the current
  tier, starting from the chunk at index equal to the index of the first bit in the block, that was
  found and set to 1 on the previous steps. Write the rest of the entry (the new value size, the
  new value and optionally checksum) after the copied part. The procedure of writing an entry is
@@ -353,7 +353,7 @@ Steps 4-5 are *in-place* value update. Steps from 6 to the end of the operation 
  20. If this step is performed for the first time, set the current tier to the first tier of this
  segment.
 
- 21. If the current tier is the last tier in the chain for the segment, i. e. the value of the [next
+ 21. If the current tier is the last tier in the chain for the segment, i.e. the value of the [next
  tier field](#next-tier-field) of the current tier is 0, go to the 22th step. Otherwise, set the
  current tier to the next linked tier. If the current tier equals to the then-current tier on the
  3rd step of this operation, repeat this step. Otherwise, go to the 8th step.
@@ -397,7 +397,7 @@ querying for some key:
  2. Read the value in the current slot.
  3. If the slot is empty this sub-operation is finished. Otherwise, continue with the next step.
  4. Compute the next hash lookup slot, by incrementing the current slot index and wrapping around
- [`tierHashLookupCapacity`](3_1-header-fields.md#tierhashlookupcapacity) (i. e. instead of
+ [`tierHashLookupCapacity`](3_1-header-fields.md#tierhashlookupcapacity) (i.e. instead of
  `tierHashLookupCapacity` the slot index becomes 0). Then continue with the 2nd step.
 
 > In the reference Java implementation, this sub-operation and the steps 3-6 of [key
@@ -423,10 +423,10 @@ probing).
 
  1. Set the *remove slot* and the *shift slot* to the slot that is going to be removed.
  2. Compute the next shift slot, by incrementing the current shift slot index and wrapping around
- [`tierHashLookupCapacity`](3_1-header-fields.md#tierhashlookupcapacity) (i. e. instead of
+ [`tierHashLookupCapacity`](3_1-header-fields.md#tierhashlookupcapacity) (i.e. instead of
  `tierHashLookupCapacity` the slot index becomes 0).
  3. Read the value in the shift slot.
- 4. If the shift slot value is 0 (i. e. the slot is empty), go to the 6th step. Otherwise, extract
+ 4. If the shift slot value is 0 (i.e. the slot is empty), go to the 6th step. Otherwise, extract
  the hash lookup key of the shift slot (at the lowest [`tierHashLookupKeyBits`](
  3_1-header-fields.md#tierhashlookupkeybits) bits of the slot value), and determine, if the remove
  slot is on the shortest slot chain between the starting search slot for the extracted hash lookup
@@ -434,7 +434,7 @@ probing).
  the remove slot (and the hash table is still correct), given that the hash table is not full. If
  so, write the shift slot value to the remove slot, set the remove slot to the current shift slot.
  5. Go to the 2nd step.
- 6. Write 0 to the remove slot, i. e. clear the slot.
+ 6. Write 0 to the remove slot, i.e. clear the slot.
 
 > The reference Java implementation: [`CompactOffHeapLinearHashTable.remove()`](
 > ../src/main/java/net/openhft/chronicle/hash/impl/CompactOffHeapLinearHashTable.java)

--- a/src/main/java/net/openhft/chronicle/hash/AbstractData.java
+++ b/src/main/java/net/openhft/chronicle/hash/AbstractData.java
@@ -37,7 +37,7 @@ public abstract class AbstractData<T> implements Data<T> {
 
     /**
      * Delegates to {@code Data}'s <i>object</i> {@code toString()}. If deserialization fails with
-     * exception (e. g. if data bytes are corrupted, and represent not a valid serialized form of
+     * exception (e.g. if data bytes are corrupted, and represent not a valid serialized form of
      * an object), traces the data's bytes and the exception.
      * Delegates to {@link #dataToString()}.
      */

--- a/src/main/java/net/openhft/chronicle/hash/ChecksumEntry.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChecksumEntry.java
@@ -28,7 +28,7 @@ public interface ChecksumEntry {
      *
      * @throws UnsupportedOperationException if checksums are not stored in the containing Chronicle
      *                                       Hash
-     * @throws RuntimeException              if the context of this entry is locked improperly, e. g. on the
+     * @throws RuntimeException              if the context of this entry is locked improperly, e.g. on the
      *                                       {@linkplain HashQueryContext#readLock() read} level, that is not upgradable to the
      *                                       {@linkplain HashQueryContext#updateLock() update} level. Calling {@code updateChecksum()}
      *                                       method is enabled when at least update lock is held.
@@ -41,7 +41,7 @@ public interface ChecksumEntry {
      * @return {@code true} if stored checksum equals to checksum computed from the entry bytes
      * @throws UnsupportedOperationException if checksums are not stored in the containing Chronicle
      *                                       Hash
-     * @throws RuntimeException              if the context of this entry is locked improperly, e. g. on the
+     * @throws RuntimeException              if the context of this entry is locked improperly, e.g. on the
      *                                       {@linkplain HashQueryContext#readLock() read} level, that is not upgradable to the
      *                                       {@linkplain HashQueryContext#updateLock() update} level. Calling {@code checkSum()} method is
      *                                       enabled when at least update lock is held.

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHash.java
@@ -24,8 +24,8 @@ import java.util.function.Predicate;
 public interface ChronicleHash<K, E extends HashEntry<K>, SC extends HashSegmentContext<K, ?>,
         EQC extends ExternalHashQueryContext<K>> extends MapClosable {
     /**
-     * Returns the file this hash container mapped to, i. e. when it is created by {@link ChronicleHashBuilder#create()} call, or {@code null} if it
-     * is purely in-memory, i. e. if it is created by {@link ChronicleHashBuilder#create()} call.
+     * Returns the file this hash container mapped to, i.e. when it is created by {@link ChronicleHashBuilder#create()} call, or {@code null} if it
+     * is purely in-memory, i.e. if it is created by {@link ChronicleHashBuilder#create()} call.
      *
      * @return the file this {@link ChronicleMap} or {@link ChronicleSet} is mapped to, or {@code null} if it is not mapped to any file
      * @see ChronicleHashBuilder#createPersistedTo(File)
@@ -185,7 +185,7 @@ public interface ChronicleHash<K, E extends HashEntry<K>, SC extends HashSegment
      * <p>
      * After this method call, all methods, querying the {@code ChronicleHash}'s entries, {@link
      * #longSize()} and {@code size()}), throw {@link ChronicleHashClosedException}. {@link #isOpen()} returns {@code false}, {@code close()} itself
-     * returns immediately without effects (i. e. repetitive {@code close()}, even from concurrent threads, are safe).
+     * returns immediately without effects (i.e. repetitive {@code close()}, even from concurrent threads, are safe).
      */
     @Override
     void close();

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 /**
- * Base interface for {@link ChronicleMapBuilder} and {@link ChronicleSetBuilder}, i. e. defines
+ * Base interface for {@link ChronicleMapBuilder} and {@link ChronicleSetBuilder}, i.e. defines
  * <i>Chronicle hash container</i> configurations.
  * <p>
  * {@code ChronicleHashBuilder} is mutable. Configuration methods mutate the builder and return
@@ -38,9 +38,9 @@ import java.util.concurrent.CountDownLatch;
  * etc.
  *
  * @param <K> the type of keys in hash containers, created by this builder
- * @param <H> the container type, created by this builder, i. e. {@link ChronicleMap} or {@link
+ * @param <H> the container type, created by this builder, i.e. {@link ChronicleMap} or {@link
  *            ChronicleSet}
- * @param <B> the concrete builder type, i. e. {@link ChronicleMapBuilder}
+ * @param <B> the concrete builder type, i.e. {@link ChronicleMapBuilder}
  *            or {@link ChronicleSetBuilder}
  */
 public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
@@ -92,12 +92,12 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * <p>
      * {@code ChronicleHashBuilder} implementation heuristically chooses
      * {@linkplain #actualChunkSize(int) the actual chunk size} based on this configuration, that,
-     * however, might result to quite high internal fragmentation, i. e. losses because only
+     * however, might result to quite high internal fragmentation, i.e. losses because only
      * integral number of chunks could be allocated for the entry. If you want to avoid this, you
      * should manually configure the actual chunk size in addition to this average key size
      * configuration, which is anyway needed.
      * <p>
-     * If key is a boxed primitive type, a value interface or {@link Byteable} subclass, i. e. if
+     * If key is a boxed primitive type, a value interface or {@link Byteable} subclass, i.e. if
      * key size is known statically, it is automatically accounted and shouldn't be specified by
      * user.
      * <p>
@@ -125,12 +125,12 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * <p>
      * {@code ChronicleHashBuilder} implementation heuristically chooses
      * {@linkplain #actualChunkSize(int) the actual chunk size} based on this configuration, that,
-     * however, might result to quite high internal fragmentation, i. e. losses because only
+     * however, might result to quite high internal fragmentation, i.e. losses because only
      * integral number of chunks could be allocated for the entry. If you want to avoid this, you
      * should manually configure the actual chunk size in addition to this average key size
      * configuration, which is anyway needed.
      * <p>
-     * If key is a boxed primitive type or {@link Byteable} subclass, i. e. if key size is known
+     * If key is a boxed primitive type or {@link Byteable} subclass, i.e. if key size is known
      * statically, it is automatically accounted and shouldn't be specified by user.
      * <p>
      * Calling this method clears any previous {@link #constantKeySizeBySample(Object)} and
@@ -151,7 +151,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * containers, created by this builder. This is done by providing the {@code sampleKey}, all
      * keys should take the same number of bytes in serialized form, as this sample object.
      * <p>
-     * If keys are of boxed primitive type or {@link Byteable} subclass, i. e. if key size is
+     * If keys are of boxed primitive type or {@link Byteable} subclass, i.e. if key size is
      * known statically, it is automatically accounted and this method shouldn't be called.
      * <p>
      * If key size varies, method {@link #averageKeySize(double)} should be called instead of
@@ -279,7 +279,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * {@code IllegalStateException}, which will quickly show you, that there is a bug in you
      * application.
      * <p>
-     * The default maximum bloat factor factor is {@code 1.0} - i. e. "no bloat is expected".
+     * The default maximum bloat factor factor is {@code 1.0} - i.e. "no bloat is expected".
      * <p>
      * It is strongly advised not to configure {@code maxBloatFactor} to more than {@code 10.0},
      * almost certainly, you either should configure {@code ChronicleHash}es completely differently,
@@ -320,7 +320,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * <p>
      * The last caveat means that the configured percentile and affects segment size relying on
      * Poisson distribution law, if inserted entries (keys) fall into all segments randomly. If
-     * e. g. the keys, inserted into the Chronicle Hash, are purposely selected to collide by
+     * e.g. the keys, inserted into the Chronicle Hash, are purposely selected to collide by
      * a certain range of hash code bits, so that they all fall into the same segment (a DOS
      * attacker might do this), this segment is obviously going to be tiered.
      * <p>
@@ -331,10 +331,10 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * mentioned in this paragraph, are specified, {@code nonTieredSegmentsPercentile} doesn't make
      * any effect.
      * <p>
-     * Default value is 0.99999, i. e. if hash code distribution of the keys is good, only one
+     * Default value is 0.99999, i.e. if hash code distribution of the keys is good, only one
      * segment of 100K is tiered on average. If your segment size is small and you want to improve
      * memory footprint of Chronicle Hash (probably compromising latency percentiles), you might
-     * want to configure more "relaxed" value, e. g. 0.99.
+     * want to configure more "relaxed" value, e.g. 0.99.
      *
      * @param nonTieredSegmentsPercentile Fraction of segments which shouldn't be tiered
      * @return this builder back
@@ -501,7 +501,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * process lifecycle.
      * <p>
      * Multiple containers could give access to the same data simultaneously, either inside a
-     * single JVM or across processes. Access is synchronized correctly across all instances, i. e.
+     * single JVM or across processes. Access is synchronized correctly across all instances, i.e.
      * hash container mapping the data from the first JVM isn't able to modify the data,
      * concurrently accessed from the second JVM by another hash container instance, mapping the
      * same data.
@@ -531,7 +531,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * leave some locks "acquired" therefore some segments inaccessible), or an accessor process
      * external termination (that, in addition to inaccessible segments, might lead to leaks in the
      * Chronicle Hash memory), or a sudden power loss, or a file corruption (that, in addition to
-     * the already mentioned consequences, might lead to data corruption, i. e. presence of entries
+     * the already mentioned consequences, might lead to data corruption, i.e. presence of entries
      * which were never put into the Chronicle Hash).
      * <p>
      * This method, unlike {@link #createPersistedTo(File)} method, expects that the given file already
@@ -599,7 +599,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * leave some locks "acquired" therefore some segments inaccessible), or an accessor process
      * external termination (that, in addition to inaccessible segments, might lead to leaks in the
      * Chronicle Hash memory), or a sudden power loss, or a file corruption (that, in addition to
-     * the already mentioned consequences, might lead to data corruption, i. e. presence of entries
+     * the already mentioned consequences, might lead to data corruption, i.e. presence of entries
      * which were never put into the Chronicle Hash).
      * <p>
      * This method, unlike {@link #createPersistedTo(File)} method,

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashCorruption.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashCorruption.java
@@ -52,7 +52,7 @@ public interface ChronicleHashCorruption {
      * applicable. E. g. if this is a segment lock word corruption, returns the index of the
      * segment, guarded by the corrupted lock. If this is an entry data corruption, returns the
      * index of the segment, in which the corrupted entry is stored. If the corruption is not
-     * associated with a particular segment, returns -1, e. g. if this is a ChronicleHash
+     * associated with a particular segment, returns -1, e.g. if this is a ChronicleHash
      * header corruption.
      */
     int segmentIndex();

--- a/src/main/java/net/openhft/chronicle/hash/Data.java
+++ b/src/main/java/net/openhft/chronicle/hash/Data.java
@@ -60,10 +60,10 @@ public interface Data<T> {
      * method.
      * <p>
      * For safety, this interface returns read-only object, because it could expose bytes source
-     * that must be immutable, e. g. a `char[]` array behind a {@code String}. But in cases when the
-     * {@code Data} instance wraps off-heap bytes, e. g. {@link MapEntry#value()}, it is allowed to
+     * that must be immutable, e.g. a `char[]` array behind a {@code String}. But in cases when the
+     * {@code Data} instance wraps off-heap bytes, e.g. {@link MapEntry#value()}, it is allowed to
      * cast the object, returned from this method, to {@link BytesStore}, and write into the
-     * off-heap memory. You should only ensure that current context (e. g. {@link MapQueryContext})
+     * off-heap memory. You should only ensure that current context (e.g. {@link MapQueryContext})
      * is locked exclusively, in order to avoid data races.
      */
     RandomDataInput bytes();
@@ -172,7 +172,7 @@ public interface Data<T> {
 
     /**
      * {@code Data} implementations should override {@link Object#toString()} with delegation to
-     * this method. Delegates to {@code Data}'s <i>object</i> {@code toString()}, i. e. equivalent
+     * this method. Delegates to {@code Data}'s <i>object</i> {@code toString()}, i.e. equivalent
      * to calling {@code get().toString()} on this {@code Data} instance with some fallback, if
      * {@code get()} method throws an exception.
      */

--- a/src/main/java/net/openhft/chronicle/hash/HashSegmentContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/HashSegmentContext.java
@@ -29,7 +29,7 @@ public interface HashSegmentContext<K, E extends HashEntry<K>> extends HashConte
      * Checks the given predicate on each <i>present</i> entry in this segment until all entries have been processed or the predicate returns {@code
      * false} for some entry, or throws an {@code Exception}. Exceptions thrown by the predicate are relayed to the caller.
      * <p>
-     * If this segment is empty (i. e. {@link #size()} call returns 0), this method returns
+     * If this segment is empty (i.e. {@link #size()} call returns 0), this method returns
      * {@code true} immediately.
      *
      * @param predicate the predicate to be checked for each entry in this segment

--- a/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashResources.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ChronicleHashResources.java
@@ -288,7 +288,7 @@ public abstract class ChronicleHashResources implements Runnable {
                 }
             }
         }
-        // Forget about contexts only if all of them are successfully closed, i. e. no throwables
+        // Forget about contexts only if all of them are successfully closed, i.e. no throwables
         // were thrown in the above loop.
         if (thrown == null) {
             // Make GC life easier
@@ -300,7 +300,7 @@ public abstract class ChronicleHashResources implements Runnable {
     private void closeContext(ContextHolder contextHolder) {
         ChainingInterface context = contextHolder.get();
         // The context could have already been cleared, if this is the second attempt to close
-        // contexts, the first one failed e. g. with IllegalStateException on one of the contexts
+        // contexts, the first one failed e.g. with IllegalStateException on one of the contexts
         // (see comment (*) below in this method), it could have succeed for some contexts and
         // contextHolder.clear() is performed.
         if (context != null) {
@@ -314,7 +314,7 @@ public abstract class ChronicleHashResources implements Runnable {
             }
 
             // (*) Don't execute contextHolder.clear() from a finally section of a try block
-            // wrapping context.closeContext(), because if context.closeContext() fails e. g. with
+            // wrapping context.closeContext(), because if context.closeContext() fails e.g. with
             // IllegalStateException because the context is currently used (this happens if
             // ChronicleMap.close() is called within try-with-resources block of it's own operation,
             // see MapCloseTest.closeInContextTest()), we may want to try to close this context
@@ -346,7 +346,7 @@ public abstract class ChronicleHashResources implements Runnable {
                 }
             }
         }
-        // Forget about closeables only if all of them are successfully closed, i. e. no throwables
+        // Forget about closeables only if all of them are successfully closed, i.e. no throwables
         // were thrown in the above loop.
         if (thrown == null) {
             // Make GC life easier
@@ -375,7 +375,7 @@ public abstract class ChronicleHashResources implements Runnable {
                 }
             }
         }
-        // Forget about memory resources only if all of them are successfully released, i. e. no
+        // Forget about memory resources only if all of them are successfully released, i.e. no
         // throwables were thrown in the above loop.
         if (thrown == null) {
             this.memoryResources = null;

--- a/src/main/java/net/openhft/chronicle/hash/impl/ContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/ContextHolder.java
@@ -9,7 +9,7 @@ import net.openhft.chronicle.hash.impl.stage.hash.ChainingInterface;
  * A simple wrapper of {@link ChainingInterface}, the ChainingInterface field could be set to null.
  * <h2>Motivation</h2>
  * <p>{@link net.openhft.chronicle.map.ChronicleMap}'s context objects are huge and reference their
- * own instances of key and value marshallers, which usually have buffers for serialization (e. g.
+ * own instances of key and value marshallers, which usually have buffers for serialization (e.g.
  * see {@link net.openhft.chronicle.hash.serialization.impl.SerializableDataAccess}). The contexts
  * are stored in {@link ThreadLocal}s, which are <i>instance</i> fields of ChronicleMap objects
  * (see {@link net.openhft.chronicle.map.VanillaChronicleMap#cxt}). We want the context objects to

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/SegmentStages.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/entry/SegmentStages.java
@@ -428,7 +428,7 @@ public abstract class SegmentStages implements SegmentLock, LocksInterface {
                 break;
             prevContext = nextNode;
         }
-        // i. e. structured unlocking
+        // i.e. structured unlocking
         verifyInnermostContext();
         prevContext.setNextNode(null);
     }

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/Chaining.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/Chaining.java
@@ -79,7 +79,7 @@ public abstract class Chaining extends ChainingInterface {
      * 1) Thread -&gt;
      * 2) ThreadLocalMap -&gt;
      * 3) Entry with ThreadLocal {@link net.openhft.chronicle.map.VanillaChronicleMap#cxt} as weak
-     * referent and a context (e. g. {@link net.openhft.chronicle.map.impl.CompiledMapQueryContext})
+     * referent and a context (e.g. {@link net.openhft.chronicle.map.impl.CompiledMapQueryContext})
      * as value (a simple field, not a weak reference!) -&gt;
      * 4) final reference to the owner {@link VanillaChronicleMap} -&gt;
      * 5) ThreadLocal {@link net.openhft.chronicle.map.VanillaChronicleMap#cxt} (a strong reference

--- a/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/ThreadLocalState.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/stage/hash/ThreadLocalState.java
@@ -42,7 +42,7 @@ public abstract class ThreadLocalState {
     public boolean lockContextLocally(ChronicleHash<?, ?, ?, ?> hash) {
         // hash().isOpen() check guarantees no starvation of a thread calling chMap.close() and
         // trying to close this context by closeContext() method below, while the thread owning this
-        // context frequently locks and unlocks it (e. g. in a loop). This is also the only check
+        // context frequently locks and unlocks it (e.g. in a loop). This is also the only check
         // for chMap openness during the whole context usage lifecycle.
         if (hash.isOpen() && MEMORY.compareAndSwapInt(this, CONTEXT_LOCK_OFFSET,
                 CONTEXT_UNLOCKED, CONTEXT_LOCKED_LOCALLY)) {
@@ -78,7 +78,7 @@ public abstract class ThreadLocalState {
         // a good idea to make this check rather than not to make.
         if (contextLock == CONTEXT_CLOSED)
             return;
-        // If first attempt of closing a context (i. e. moving from unused to closed state) failed,
+        // If first attempt of closing a context (i.e. moving from unused to closed state) failed,
         // it means that the context is still in use. If this context belongs to the current thread,
         // this is a bug, because we cannot "wait" until context is unused in the same thread:
         if (owner() == Thread.currentThread()) {
@@ -114,7 +114,7 @@ public abstract class ThreadLocalState {
                 "- The context owner thread exited before closing this context. Ensure that you\n" +
                 "always close opened Chronicle Map's contexts, the best way to do this is to use\n" +
                 "try-with-resources blocks." +
-                "- The context owner thread runs some context operation (e. g. a query) for\n" +
+                "- The context owner thread runs some context operation (e.g. a query) for\n" +
                 "unexpectedly long time (at least " + LOCK_TIMEOUT_SECONDS + " seconds).\n" +
                 "You should either redesign your logic to spend less time in Chronicle Map\n" +
                 "contexts (recommended) or synchronize map.close() with queries externally,\n" +

--- a/src/main/java/net/openhft/chronicle/hash/locks/InterProcessLock.java
+++ b/src/main/java/net/openhft/chronicle/hash/locks/InterProcessLock.java
@@ -22,7 +22,7 @@ import java.util.concurrent.locks.Lock;
  * threads</i>, instead of that, lock objects should be obtained in each thread separately, using
  * the same call chain. This is because since the lock is inter-process, it anyway keeps it's
  * synchronization state in shared off-heap memory, but restricting on-heap "view" of shared lock
- * to a single thread is beneficial form performance point-of-view, e. g. fields of the on-heap
+ * to a single thread is beneficial form performance point-of-view, e.g. fields of the on-heap
  * {@code InterProcessLock} object shouldn't be {@code volatile}.
  * <p>
  * Lock is inter-process, hence it cannot afford to wait for acquisition infinitely, because
@@ -61,7 +61,7 @@ public interface InterProcessLock extends Lock {
      * {@link InterProcessDeadLockException} is thrown.
      *
      * @throws IllegalMonitorStateException  if this method call observes illegal lock state, or some
-     *                                       lock limitations reached (e. g. maximum read lock holders)
+     *                                       lock limitations reached (e.g. maximum read lock holders)
      * @throws InterProcessDeadLockException if fails to acquire a lock for some finite time
      */
     @Override
@@ -88,7 +88,7 @@ public interface InterProcessLock extends Lock {
      *
      * @throws InterruptedException          if the current thread is interrupted while acquiring the lock
      * @throws IllegalMonitorStateException  if this method call observes illegal lock state, or some
-     *                                       lock limitations reached (e. g. maximum read lock holders)
+     *                                       lock limitations reached (e.g. maximum read lock holders)
      * @throws InterProcessDeadLockException if fails to acquire a lock for some finite time
      */
     @Override
@@ -129,7 +129,7 @@ public interface InterProcessLock extends Lock {
      *
      * @return {@code true} if the lock was acquired and {@code false} otherwise
      * @throws IllegalMonitorStateException if this method call observes illegal lock state, or some
-     *                                      lock limitations reached (e. g. maximum read lock holders)
+     *                                      lock limitations reached (e.g. maximum read lock holders)
      */
     @Override
     boolean tryLock();

--- a/src/main/java/net/openhft/chronicle/hash/replication/RemoteOperationContext.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/RemoteOperationContext.java
@@ -31,7 +31,7 @@ public interface RemoteOperationContext<K> extends HashContext<K> {
     /**
      * Returns the identifier of the node, from which current replication event came from, or -1 if
      * unknown or not applicable (the current replication event came not from another node, but,
-     * e. g., applied manually).
+     * e.g., applied manually).
      */
     byte remoteNodeIdentifier();
 }

--- a/src/main/java/net/openhft/chronicle/hash/replication/ReplicableEntry.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/ReplicableEntry.java
@@ -94,7 +94,7 @@ public interface ReplicableEntry {
      * Check is the entry is scheduled to be replicated to the remote Chronicle nodes, to which
      * the connection is currently established.
      *
-     * @return {@code true} is the entry is "dirty" locally, i. e. should be replicated to any of
+     * @return {@code true} is the entry is "dirty" locally, i.e. should be replicated to any of
      * remote Chronicle nodes, {@code false} otherwise
      */
     boolean isChanged();

--- a/src/main/java/net/openhft/chronicle/hash/replication/TimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/hash/replication/TimeProvider.java
@@ -55,7 +55,7 @@ public final class TimeProvider {
     }
 
     /**
-     * Returns system time interval (i. e. wall time interval) between two time values, taken using
+     * Returns system time interval (i.e. wall time interval) between two time values, taken using
      * {@link #currentTime()} method, with the highest possible precision, in the given time units.
      *
      * @param earlierTime            {@link #currentTime()} result, taken at some moment in the past (earlier)

--- a/src/main/java/net/openhft/chronicle/hash/serialization/BytesReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/BytesReader.java
@@ -28,14 +28,14 @@ import org.jetbrains.annotations.Nullable;
 public interface BytesReader<T> extends Marshallable {
 
     /**
-     * Reads and returns the object from {@link Bytes#readPosition()} (i. e. the current position)
-     * in the given {@code in}. Should attempt to reuse the given {@code using} object, i. e. to
+     * Reads and returns the object from {@link Bytes#readPosition()} (i.e. the current position)
+     * in the given {@code in}. Should attempt to reuse the given {@code using} object, i.e. to
      * read the deserialized data into the given object. If it is possible, this object then
      * returned from this method back. If it is impossible for any reason, a new object should be
      * created and returned. The given {@code using} object could be {@code null}, in this case this
      * method, of cause, should create a new object.
      * <p>
-     * This method should increment the position in the given {@code Bytes}, i. e. consume the
+     * This method should increment the position in the given {@code Bytes}, i.e. consume the
      * read bytes. {@code in} bytes shouldn't be written.
      *
      * @param in    the {@code Bytes} to read the object from

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SizedReader.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SizedReader.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Deserializer of objects from bytes, pairing {@link SizedWriter}, i. e. assuming the length
+ * Deserializer of objects from bytes, pairing {@link SizedWriter}, i.e. assuming the length
  * of the serialized form isn't written in the beginning of the serialized form itself, but managed
  * by {@link ChronicleHash} implementation and passed to the reading methods.
  * <p>
@@ -34,9 +34,9 @@ import org.jetbrains.annotations.Nullable;
 public interface SizedReader<T> extends Marshallable {
 
     /**
-     * Reads and returns the object from {@link Bytes#readPosition()} (i. e. the current position)
+     * Reads and returns the object from {@link Bytes#readPosition()} (i.e. the current position)
      * to {@code Bytes.readPosition() + size} in the given {@code in}. Should attempt to reuse the
-     * given {@code using} object, i. e. to read the deserialized data into the given object. If it
+     * given {@code using} object, i.e. to read the deserialized data into the given object. If it
      * is possible, this objects then returned from this method. If it is impossible for any reason,
      * a new object should be created and returned. The given {@code using} object could be {@code
      * null}, in this case read() should always create a new object.

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SizedWriter.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SizedWriter.java
@@ -31,7 +31,7 @@ public interface SizedWriter<T> extends Marshallable {
 
     /**
      * Returns the length (in bytes) of the serialized form of the given object. Serialization form
-     * in terms of this interface, i. e. how much bytes are written to {@code out} on
+     * in terms of this interface, i.e. how much bytes are written to {@code out} on
      * {@link #write(Bytes, long, Object) write(out, size, toWrite)} call.
      *
      * @param toWrite the object which serialized form length should be returned
@@ -52,7 +52,7 @@ public interface SizedWriter<T> extends Marshallable {
      * @param out     the {@code Bytes} to write the given object to
      * @param size    the size, returned by {@link #size(Object)} for the given {@code toWrite} object.
      *                it is given, because size might be needed during serialization, and it's computation has
-     *                non-constant complexity, i. e. if serializing a {@code CharSequence} using variable-length
+     *                non-constant complexity, i.e. if serializing a {@code CharSequence} using variable-length
      *                encoding like UTF-8.
      * @param toWrite the object to serialize
      * @see SizedReader#read(Bytes, long, Object)

--- a/src/main/java/net/openhft/chronicle/hash/serialization/StatefulCopyable.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/StatefulCopyable.java
@@ -44,13 +44,13 @@ public interface StatefulCopyable<T extends StatefulCopyable<T>> {
     /**
      * Creates a copy of this marshaller, with independent state. The current state itself shouldn't
      * be copied (it could be "clear" in the copy), only "configuration" of the instance, on which
-     * {@code copy()} is called, should be inherited in the copy (e. g. the class of objects
-     * serialized). So, {@code copy()} should be transitive, i. e. {@code marshaller.copy()} and
+     * {@code copy()} is called, should be inherited in the copy (e.g. the class of objects
+     * serialized). So, {@code copy()} should be transitive, i.e. {@code marshaller.copy()} and
      * {@code marshaller.copy().copy()} should result to identical instances.
      * <p>
      * The state of the instance on which {@code copy()} is called shouldn't be changed.
      * <p>
-     * If some marshaller is ought to implement {@code StatefulCopyable} interface (e. g.
+     * If some marshaller is ought to implement {@code StatefulCopyable} interface (e.g.
      * {@link DataAccess}) but is stateless actually, it could return {@code this} from this method.
      *
      * @return the copy if this marshaller with the same configuration, but independent state

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/InstanceCreatingMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/InstanceCreatingMarshaller.java
@@ -52,7 +52,7 @@ public abstract class InstanceCreatingMarshaller<T> implements Marshallable {
 
     /**
      * Creates a new {@code T} instance by calling {@link Class#newInstance()}. If you need
-     * different logic, i. e. calling a constructor with parameter, override this method in a
+     * different logic, i.e. calling a constructor with parameter, override this method in a
      * subclass of the specific {@link DataAccess} or {@link SizedReader} and configure in {@link
      * ChronicleMapBuilder}.
      *

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMap.java
@@ -126,7 +126,7 @@ public interface ChronicleMap<K, V> extends ConcurrentMap<K, V>,
      * Where {@code defaultValue(key)} returns {@link
      * ChronicleMapBuilder#defaultValueProvider(DefaultValueProvider) defaultValueProvider}.
      * <p>
-     * If the {@code ChronicleMap} is off-heap updatable, i. e. created via {@link
+     * If the {@code ChronicleMap} is off-heap updatable, i.e. created via {@link
      * ChronicleMapBuilder} builder (values are {@link Byteable}), there is one more option of what
      * to do if the key is absent in the map. By default, value bytes are just zeroed out, no
      * default value, either provided for key or constant, is put for the absent key.
@@ -178,7 +178,7 @@ public interface ChronicleMap<K, V> extends ConcurrentMap<K, V>,
      * when accessing {@code ChronicleMap} implementation which delegates it's requests to some
      * remote node (server) and pulls the result through serialization/deserialization path, and
      * probably network. In this case, when you actually need only a part of the map value's state
-     * (e. g. a single field) it's cheaper to extract it on the server side and transmit lesser
+     * (e.g. a single field) it's cheaper to extract it on the server side and transmit lesser
      * bytes.
      *
      * @param key      the key whose associated value is to be queried
@@ -287,7 +287,7 @@ public interface ChronicleMap<K, V> extends ConcurrentMap<K, V>,
      * The maximum number of times, the chronicle map is allowed to grow in size beyond
      * the configured number of entries.
      * <p>
-     * The default maximum bloat factor is {@code 1.0} - i. e. "no bloat is expected".
+     * The default maximum bloat factor is {@code 1.0} - i.e. "no bloat is expected".
      * <p>
      * It is strongly advised not to configure {@code maxBloatFactor} to more than {@code 10.0},
      * almost certainly, you either should configure {@code ChronicleHash}es completely differently,

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -83,7 +83,7 @@ import static net.openhft.chronicle.map.VanillaChronicleMap.alignAddr;
  * <p>
  * ChronicleMap<Key, Value> map1 = builder.create();
  * ChronicleMap<Key, Value> map2 = builder.create();}</pre>
- * i. e. created {@code ChronicleMap} instances don't depend on the builder.
+ * i.e. created {@code ChronicleMap} instances don't depend on the builder.
  * <p>
  * {@code ChronicleMapBuilder} is mutable, see a note in {@link ChronicleHashBuilder} interface
  * documentation.
@@ -595,12 +595,12 @@ public final class ChronicleMapBuilder<K, V> implements
      * <p>
      * {@code ChronicleHashBuilder} implementation heuristically chooses {@linkplain
      * #actualChunkSize(int) the actual chunk size} based on this configuration and the key size,
-     * that, however, might result to quite high internal fragmentation, i. e. losses because only
+     * that, however, might result to quite high internal fragmentation, i.e. losses because only
      * integral number of chunks could be allocated for the entry. If you want to avoid this, you
      * should manually configure the actual chunk size in addition to this average value size
      * configuration, which is anyway needed.
      * <p>
-     * If values are of boxed primitive type or {@link Byteable} subclass, i. e. if value size is
+     * If values are of boxed primitive type or {@link Byteable} subclass, i.e. if value size is
      * known statically, it is automatically accounted and shouldn't be specified by user.
      * <p>
      * Calling this method clears any previous {@link #constantValueSizeBySample(Object)} and
@@ -635,12 +635,12 @@ public final class ChronicleMapBuilder<K, V> implements
      * <p>
      * {@code ChronicleHashBuilder} implementation heuristically chooses {@linkplain
      * #actualChunkSize(int) the actual chunk size} based on this configuration and the key size,
-     * that, however, might result to quite high internal fragmentation, i. e. losses because only
+     * that, however, might result to quite high internal fragmentation, i.e. losses because only
      * integral number of chunks could be allocated for the entry. If you want to avoid this, you
      * should manually configure the actual chunk size in addition to this average value size
      * configuration, which is anyway needed.
      * <p>
-     * If values are of boxed primitive type or {@link Byteable} subclass, i. e. if value size is
+     * If values are of boxed primitive type or {@link Byteable} subclass, i.e. if value size is
      * known statically, it is automatically accounted and shouldn't be specified by user.
      * <p>
      * Calling this method clears any previous {@link #constantValueSizeBySample(Object)}
@@ -676,7 +676,7 @@ public final class ChronicleMapBuilder<K, V> implements
      * created by this builder. This is done by providing the {@code sampleValue}, all values should
      * take the same number of bytes in serialized form, as this sample object.
      * <p>
-     * If values are of boxed primitive type or {@link Byteable} subclass, i. e. if value size is
+     * If values are of boxed primitive type or {@link Byteable} subclass, i.e. if value size is
      * known statically, it is automatically accounted and this method shouldn't be called.
      * <p>
      * If value size varies, method {@link #averageValue(Object)} or {@link
@@ -903,14 +903,14 @@ public final class ChronicleMapBuilder<K, V> implements
 
     /**
      * Configures alignment of address in memory of entries and independently of address in memory
-     * of values within entries ((i. e. final addresses in native memory are multiples of the given
+     * of values within entries ((i.e. final addresses in native memory are multiples of the given
      * alignment) for ChronicleMaps, created by this builder.
      * <p>
      * Useful when values of the map are updated intensively, particularly fields with volatile
      * access, because it doesn't work well if the value crosses cache lines. Also, on some
      * (nowadays rare) architectures any misaligned memory access is more expensive than aligned.
      * <p>
-     * If values couldn't reference off-heap memory (i. e. it is not {@link Byteable} or a value
+     * If values couldn't reference off-heap memory (i.e. it is not {@link Byteable} or a value
      * interface), alignment configuration makes no sense.
      * <p>
      * Default is {@link ValueModel#recommendedOffsetAlignment()} if the value type is a value
@@ -971,7 +971,7 @@ public final class ChronicleMapBuilder<K, V> implements
     long entries() {
         if (entries < 0) {
             throw new IllegalStateException("If in-memory Chronicle Map is created or persisted\n" +
-                    "to a file for the first time (i. e. not accessing an existing file),\n" +
+                    "to a file for the first time (i.e. not accessing an existing file),\n" +
                     "ChronicleMapBuilder.entries() must be configured.\n" +
                     "See Chronicle Map 3 tutorial and javadocs for more information");
         }
@@ -1208,10 +1208,10 @@ public final class ChronicleMapBuilder<K, V> implements
         final int segments = actualSegments();
 
         final long pageSize = OS.pageSize();
-        if (segments * (64 * 3) < (2 * pageSize)) // i. e. <= 42 segments, if page size is 4K
+        if (segments * (64 * 3) < (2 * pageSize)) // i.e. <= 42 segments, if page size is 4K
             return 64 * 3; // cache line per header, plus one CL to the left, plus one to the right
 
-        if (segments * (64 * 2) < (3 * pageSize)) // i. e. <= 96 segments, if page size is 4K
+        if (segments * (64 * 2) < (3 * pageSize)) // i.e. <= 96 segments, if page size is 4K
             return 64 * 2;
 
         // reduce false sharing unless we have a lot of segments.

--- a/src/main/java/net/openhft/chronicle/map/DefaultValueProvider.java
+++ b/src/main/java/net/openhft/chronicle/map/DefaultValueProvider.java
@@ -19,7 +19,7 @@ public interface DefaultValueProvider<K, V> {
     /**
      * Returns the "nil" value, which should be inserted into the map, in the given
      * {@code absentEntry} context. This is primarily used in {@link ChronicleMap#acquireUsing}
-     * operation implementation, i. e. {@link MapMethods#acquireUsing}.
+     * operation implementation, i.e. {@link MapMethods#acquireUsing}.
      * <p>
      * The default implementation simply delegates to {@link MapAbsentEntry#defaultValue()}.
      */

--- a/src/main/java/net/openhft/chronicle/map/MapAbsentEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/MapAbsentEntry.java
@@ -39,7 +39,7 @@ public interface MapAbsentEntry<K, V> extends HashAbsentEntry<K> {
     /**
      * Returns the <i>default</i> (or <i>nil</i>) value, that should be inserted into the map in
      * this context. This is primarily used in {@link ChronicleMap#acquireUsing} operation
-     * implementation, i. e. {@link MapMethods#acquireUsing}.
+     * implementation, i.e. {@link MapMethods#acquireUsing}.
      * <p>
      * This method if the default implementation for {@link
      * DefaultValueProvider#defaultValue(MapAbsentEntry)},

--- a/src/main/java/net/openhft/chronicle/map/MapContext.java
+++ b/src/main/java/net/openhft/chronicle/map/MapContext.java
@@ -38,7 +38,7 @@ public interface MapContext<K, V, R>
     /**
      * Wraps the given value as a {@code Data}. Useful when you need to pass a value
      * to some method accepting {@code Data}, for example, {@link MapEntryOperations#replaceValue(
-     *MapEntry, Data)}, without allocating new objects (i. e. garbage) and {@code ThreadLocals}.
+     *MapEntry, Data)}, without allocating new objects (i.e. garbage) and {@code ThreadLocals}.
      * <p>
      * The returned {@code Data} object shouldn't outlive this {@code MapContext}.
      *

--- a/src/main/java/net/openhft/chronicle/map/MapEntryOperations.java
+++ b/src/main/java/net/openhft/chronicle/map/MapEntryOperations.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
  * By default {@link #remove}, {@link #insert} and {@link #replaceValue} return {@code null},
  * but subclasses could return something more sensible, to be used in higher-level SPI interfaces,
  * namely {@link MapMethods} and {@link MapRemoteOperations}. For example, in bidirectional map
- * implementation (i. e. a map that preserves the uniqueness of its values as well as that of
+ * implementation (i.e. a map that preserves the uniqueness of its values as well as that of
  * its keys), that includes two {@code ChronicleMaps}, the {@code MapEntryOperations}' methods return
  * type could be used to indicate if we were successful to lock both maps before performing
  * the update: <pre>
@@ -95,7 +95,7 @@ public interface MapEntryOperations<K, V, R> {
      * and returns {@code null}.
      *
      * @param entry the entry to remove
-     * @return result of operation, understandable by higher-level SPIs, e. g. custom
+     * @return result of operation, understandable by higher-level SPIs, e.g. custom
      * {@link MapMethods} implementation
      * @throws IllegalStateException if some locking/state conditions required to perform remove
      *                               operation are not met
@@ -112,7 +112,7 @@ public interface MapEntryOperations<K, V, R> {
      * entry.doReplaceValue(newValue)} and returns {@code null}.
      *
      * @param entry the entry to replace the value in
-     * @return result of operation, understandable by higher-level SPIs, e. g. custom
+     * @return result of operation, understandable by higher-level SPIs, e.g. custom
      * {@link MapMethods} implementation
      * @throws IllegalStateException if some locking/state conditions required to perform replace
      *                               operation are not met
@@ -130,7 +130,7 @@ public interface MapEntryOperations<K, V, R> {
      * Note: default implementation calls {@link MapAbsentEntry#doInsert(Data)
      * absentEntry.doInsert(value)} and returns {@code null}.
      *
-     * @return result of operation, understandable by higher-level SPIs, e. g. custom
+     * @return result of operation, understandable by higher-level SPIs, e.g. custom
      * {@link MapMethods} implementation
      * @throws IllegalStateException if some locking/state conditions required to perform insertion
      *                               operation are not met

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -297,7 +297,7 @@ public class ReplicatedChronicleMap<K, V, R> extends VanillaChronicleMap<K, V, R
                     "replicated Chronicle Map. This should only be possible if persisted\n" +
                     "replicated Chronicle Map access from another process/JVM run/after\n" +
                     "a transfer from another machine, and replication identifier is not\n" +
-                    "specified when access is configured, e. g. ChronicleMap.of(...)" +
+                    "specified when access is configured, e.g. ChronicleMap.of(...)" +
                     ".createPersistedTo(existingFile).\n" +
                     "In this case, replicated Chronicle Map \"doesn't know\" it's identifier,\n" +
                     "and is able to perform simple _read_ operations like map.get(), which\n" +

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/entry/MapEntryStages.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/entry/MapEntryStages.java
@@ -82,7 +82,7 @@ public abstract class MapEntryStages<K, V> extends HashEntryStages<K>
         // 3) update entry checksum
         // but the actual entry replacement is not needed, if the value object is a flyweight over
         // the off-heap bytes. This condition avoids in-place data copy.
-        // TODO would be nice to reduce scope of this check, i. e. check only when it could be
+        // TODO would be nice to reduce scope of this check, i.e. check only when it could be
         // true, and avoid when it surely false (fresh value put, relocating put etc.)
         // TODO this optimization is now disabled, because it calls value.bytes() that forces double
         // data copy, if sizedReader/Writer configured for the value.

--- a/src/main/java/net/openhft/chronicle/map/replication/MapRemoteOperations.java
+++ b/src/main/java/net/openhft/chronicle/map/replication/MapRemoteOperations.java
@@ -58,7 +58,7 @@ import static net.openhft.chronicle.hash.replication.DefaultEventualConsistencyS
 public interface MapRemoteOperations<K, V, R> {
 
     /**
-     * Handle remote {@code remove} call and {@code remove} replication event, i. e. when the entry
+     * Handle remote {@code remove} call and {@code remove} replication event, i.e. when the entry
      * with the query key ({@code q.queriedKey()}) was removed on some {@code ChronicleMap} node.
      *
      * @param q the remote operation context
@@ -117,7 +117,7 @@ public interface MapRemoteOperations<K, V, R> {
     }
 
     /**
-     * Handle remote {@code put} call or replication event, i. e. when the entry with the queried
+     * Handle remote {@code put} call or replication event, i.e. when the entry with the queried
      * key ({@code q.queriedKey()}) was changed on some remote {@code ChronicleMap} node, with the
      * given {@code newValue}.
      *

--- a/src/main/java/net/openhft/chronicle/map/replication/MapRemoteQueryContext.java
+++ b/src/main/java/net/openhft/chronicle/map/replication/MapRemoteQueryContext.java
@@ -32,7 +32,7 @@ public interface MapRemoteQueryContext<K, V, R> extends MapQueryContext<K, V, R>
      * ChronicleMapBuilder#valueSizeMarshaller(SizeMarshaller) the configured value size
      * marshaller}.
      * <p>
-     * The returned value doesn't have object form (i. e. it's {@link Data#get()} and {@link
+     * The returned value doesn't have object form (i.e. it's {@link Data#get()} and {@link
      * Data#getUsing(Object)} methods throw {@code UnsupportedOperationException}), it has only
      * bytes form, of all zero bytes.
      *

--- a/src/test/java/net/openhft/chronicle/map/ExitHookTest.java
+++ b/src/test/java/net/openhft/chronicle/map/ExitHookTest.java
@@ -131,7 +131,7 @@ public class ExitHookTest {
             assertEquals(130, actual); // 130 is exit code for SIGINT (interruption).
         ChronicleMap<Integer, Integer> map = createMapBuilder().createPersistedTo(mapFile);
         try (ExternalMapQueryContext<Integer, Integer, ?> c = map.queryContext(KEY)) {
-            // Test that we are able to lock the segment, i. e. the lock was released in other
+            // Test that we are able to lock the segment, i.e. the lock was released in other
             // process, thanks to default shutdown hook.
             c.writeLock().lock();
         }
@@ -158,7 +158,7 @@ public class ExitHookTest {
             assertEquals(130, actual); // 130 is exit code for SIGINT (interruption).
         ChronicleMap<Integer, Integer> map = createMapBuilder().createPersistedTo(mapFile);
         try (ExternalMapQueryContext<Integer, Integer, ?> c = map.queryContext(KEY)) {
-            // Test that we are able to lock the segment, i. e. the lock was released in other
+            // Test that we are able to lock the segment, i.e. the lock was released in other
             // process, thanks to user shutdown hook.
             c.writeLock().lock();
         }


### PR DESCRIPTION
## Summary
- Replaces `i. e.` with `i.e.` and `e. g.` with `e.g.` in javadoc / AsciiDoc / Markdown.
- Matches conventional English rendering and the style used elsewhere in these repos.
- Behaviour-neutral text change, but a few replacements are in user-facing exception/help strings inside executable code (`ThreadLocalState`, `ChronicleMapBuilder`, `ReplicatedChronicleMap`).

## Test plan
- [ ] Visual diff - only abbreviation spacing changes.
- [ ] Runtime-visible string changes are limited to punctuation/spacing.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)