### PR TITLE
docs: update stale GitHub branch references (master -> develop/ea)

### DIFF
--- a/docs/CM_Features.adoc
+++ b/docs/CM_Features.adoc
@@ -31,9 +31,9 @@ NOTE: See <<CM_Replication.adoc#,Chronicle Map Replication>> for more informatio
 
 **Chronicle Map** has two meanings:
 
-- https://github.com/OpenHFT/Chronicle-Map/blob/master/spec[language-agnostic data store (specification)].
+- https://github.com/OpenHFT/Chronicle-Map/blob/develop/spec[language-agnostic data store (specification)].
 
-- https://github.com/OpenHFT/Chronicle-Map/blob/master/src[implementation of this data store for the JVM (source)].
+- https://github.com/OpenHFT/Chronicle-Map/blob/develop/src[implementation of this data store for the JVM (source)].
 Currently, this is the only implementation.
 
 === From the Java perspective
@@ -80,7 +80,7 @@ It is split into independent segments; each segment has:
 
 - a lock in shared memory (implemented via CAS loops) for managing concurrent access.
 
-See https://github.com/OpenHFT/Chronicle-Map/blob/master/spec[Chronicle Map data store design overview] for more information.
+See https://github.com/OpenHFT/Chronicle-Map/blob/develop/spec[Chronicle Map data store design overview] for more information.
 
 == Chronicle Map is not
 

--- a/docs/CM_Tutorial_Understanding.adoc
+++ b/docs/CM_Tutorial_Understanding.adoc
@@ -67,7 +67,7 @@ See examples of implementing this interface in <<CM_Tutorial_Bytes.adoc#custom-c
 It is permissable to return `this` from the `copy()` method, if the serializer implementation doesn't have a state.
 
 Typically this is the case when the serializer is configured with sub-serializers, which might be `StatefulCopyable`, or not.
-For example, the  https://github.com/OpenHFT/Chronicle-Map/blob/master/src/main/java/net/openhft/chronicle/hash/serialization/ListMarshaller.java[`ListMarshaller`]
+For example, the  https://github.com/OpenHFT/Chronicle-Map/blob/develop/src/main/java/net/openhft/chronicle/hash/serialization/ListMarshaller.java[`ListMarshaller`]
 class.
 
 '''

--- a/spec/3_2-lock-structure.md
+++ b/spec/3_2-lock-structure.md
@@ -177,7 +177,7 @@ acquiring read and update lock](#time-limited-read-or-update-lock-acquisition).
 > ## The reference Java implementation
 >
 > Attempt, release and downgrade operations: [`VanillaReadWriteUpdateWithWaitsLockingStrategy`](
-> https://github.com/OpenHFT/Chronicle-Algorithms/blob/master/src/main/java/net/openhft/chronicle/algo/locks/VanillaReadWriteUpdateWithWaitsLockingStrategy.java)
+> https://github.com/OpenHFT/Chronicle-Algorithms/blob/develop/src/main/java/net/openhft/chronicle/algo/locks/VanillaReadWriteUpdateWithWaitsLockingStrategy.java)
 >
 > Time-limited operations: [`BigSegmentHeader`](
 > ../src/main/java/net/openhft/chronicle/hash/impl/BigSegmentHeader.java)

--- a/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
@@ -115,7 +115,7 @@ public class VanillaChronicleMap<K, V, R>
         }
         Announcer.announce("net.openhft", "chronicle-map",
                 AnalyticsFacade.isEnabled()
-                        ? singletonMap("Analytics", "Chronicle Map reports usage statistics. Learn more or turn off: https://github.com/OpenHFT/Chronicle-Map/blob/master/DISCLAIMER.adoc")
+                        ? singletonMap("Analytics", "Chronicle Map reports usage statistics. Learn more or turn off: https://github.com/OpenHFT/Chronicle-Map/blob/develop/DISCLAIMER.adoc")
                         : emptyMap());
         AnalyticsHolder.instance().sendEvent("started", additionalEventParameters);
     }


### PR DESCRIPTION
## Summary
- Own-repo and OpenHFT repos that default to `develop` now use `/blob/develop/` and `/tree/develop/`.
- Chronicle-Bytes references move to `/blob/ea/` (its default branch).
- OpenHFT/RFC references remain on `master` (still its default).
- One updated link lives inside the runtime analytics announcement string in `VanillaChronicleMap`; behaviour is unchanged apart from the displayed URL.

## Test plan
- [ ] Clicking the updated links lands on a valid file/tree page.
- [ ] Runtime announcement text change is limited to the URL target.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)