### PR TITLE
docs: replace above-U+00FF characters with 8-bit equivalents

### DIFF
--- a/ReadMe.adoc
+++ b/ReadMe.adoc
@@ -30,26 +30,26 @@ image::docs/images/Image1_.png[750,650]
 
 Chronicle Map is used in production around the world for:
 
-• **real-time trading systems**.
+* **real-time trading systems**.
 Chronicle Map provides in-memory access speeds, and supports ultra-low garbage collection.
 Chronicle Map can support the most demanding of applications.
-• **highly concurrent systems**.
+* **highly concurrent systems**.
 Chronicle Map supports multiple readers and writers, distributed across multiple machines.
 
 === Why use Chronicle Map?
 
 Chronicle Map is:
 
-• **fast**.
+* **fast**.
 Millions of operations per second, with low and stable microsecond latencies for reads and writes.
 Write queries scale well up to the number of hardware execution threads in the server.
 Read queries never block each other.
-• **reliable**.
+* **reliable**.
 Chronicle Software have a "chaos monkey" test which verifies Chronicle Map multi-master replication in the face of node and network failures.
 The map can optionally be persisted to disk.
-• **in production** at banks and hedge funds, globally.
-• **built using lessons learnt** from real-world experience solving real-world problems.
-• **open source** (standard version), and in use at hundreds of sites around the world.
+* **in production** at banks and hedge funds, globally.
+* **built using lessons learnt** from real-world experience solving real-world problems.
+* **open source** (standard version), and in use at hundreds of sites around the world.
 
 === Our offering
 

--- a/ReadMe.adoc
+++ b/ReadMe.adoc
@@ -45,7 +45,7 @@ Millions of operations per second, with low and stable microsecond latencies for
 Write queries scale well up to the number of hardware execution threads in the server.
 Read queries never block each other.
 • **reliable**.
-Chronicle Software have a “chaos monkey” test which verifies Chronicle Map multi-master replication in the face of node and network failures.
+Chronicle Software have a "chaos monkey" test which verifies Chronicle Map multi-master replication in the face of node and network failures.
 The map can optionally be persisted to disk.
 • **in production** at banks and hedge funds, globally.
 • **built using lessons learnt** from real-world experience solving real-world problems.

--- a/docs/CM_FAQs.adoc
+++ b/docs/CM_FAQs.adoc
@@ -65,7 +65,7 @@ However, we encourage all our clients to use Linux, as it has improved handling 
 
 === Question
 
-Will Chronicle Map work in *Docker* environments “out-of-the-box”.
+Will Chronicle Map work in *Docker* environments "out-of-the-box".
 For example, two java programs running on dockers?
 
 === Answer

--- a/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
+++ b/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
@@ -77,7 +77,7 @@ class OldDeletedEntriesCleanupThread extends Thread
         return a;
     }
 
-    // Implementing Fisher–Yates shuffle
+    // Implementing Fisher-Yates shuffle
     private static void shuffle(int[] a) {
         SecureRandom rnd = new SecureRandom();
         for (int i = a.length - 1; i > 0; i--) {

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -51,7 +51,7 @@ import static net.openhft.chronicle.hash.replication.TimeProvider.currentTime;
  * number of nodes will be fixed. The data that is stored locally in each node will become
  * eventually consistent. So changes made to one node, for example by calling put() will be
  * replicated over to the other node. To achieve a high level of performance and throughput, the
- * call to put() won’t block, with concurrentHashMap, It is typical to check the return code of some
+ * call to put() won't block, with concurrentHashMap, It is typical to check the return code of some
  * methods to obtain the old value for example remove(). Due to the loose coupling and lock free
  * nature of this multi master implementation,  this return value will only be the old value on the
  * nodes local data store. In other words the nodes are only concurrent locally. Its worth realising

--- a/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
+++ b/src/test/java/net/openhft/chronicle/map/CHMUseCasesTest.java
@@ -126,7 +126,7 @@ interface IBean {
 
     Inner getInnerAt(int index);
 
-    /* nested interface - empowering an Off-Heap hierarchical “TIER of prices”
+    /* nested interface - empowering an Off-Heap hierarchical "TIER of prices"
     as array[ ] value */
     interface Inner {
 

--- a/src/test/java/net/openhft/chronicle/map/fromdocs/BondVOInterface.java
+++ b/src/test/java/net/openhft/chronicle/map/fromdocs/BondVOInterface.java
@@ -40,7 +40,7 @@ public interface BondVOInterface {
 
     void setSymbol(@MaxUtf8Length(20) String symbol);
 
-    // OpenHFT Off-Heap array[ ] processing notice ‘At’ suffix
+    // OpenHFT Off-Heap array[ ] processing notice 'At' suffix
     @Group(1)
     @Array(length = 7)
     void setMarketPxIntraDayHistoryAt(int tradingDayHour, MarketPx mPx);
@@ -48,13 +48,13 @@ public interface BondVOInterface {
     /* 7 Hours in the Trading Day:
      * index_0 = 9.30am,
      * index_1 = 10.30am,
-     …,
+     ...,
      * index_6 = 4.30pm
      */
 
     MarketPx getMarketPxIntraDayHistoryAt(int tradingDayHour);
 
-    /* nested interface - empowering an Off-Heap hierarchical “TIER of prices”
+    /* nested interface - empowering an Off-Heap hierarchical "TIER of prices"
     as array[ ] value */
     interface MarketPx {
         double getCallPx();

--- a/src/test/java/net/openhft/chronicle/map/locks/BondVOInterface.java
+++ b/src/test/java/net/openhft/chronicle/map/locks/BondVOInterface.java
@@ -40,7 +40,7 @@ public interface BondVOInterface {
 
     void setSymbol(@MaxUtf8Length(20) String symbol);
 
-    // OpenHFT Off-Heap array[ ] processing notice ‘At’ suffix
+    // OpenHFT Off-Heap array[ ] processing notice 'At' suffix
     @Group(1)
     @Array(length = 7)
     void setMarketPxIntraDayHistoryAt(int tradingDayHour, MarketPx mPx);
@@ -48,13 +48,13 @@ public interface BondVOInterface {
     /* 7 Hours in the Trading Day:
      * index_0 = 9.30am,
      * index_1 = 10.30am,
-     …,
+     ...,
      * index_6 = 4.30pm
      */
 
     MarketPx getMarketPxIntraDayHistoryAt(int tradingDayHour);
 
-    /* nested interface - empowering an Off-Heap hierarchical “TIER of prices”
+    /* nested interface - empowering an Off-Heap hierarchical "TIER of prices"
     as array[ ] value */
     interface MarketPx {
         double getCallPx();


### PR DESCRIPTION
## Summary
Documentation is expected to stay within 8-bit (1-255) so characters outside that range are folded to their closest Latin-1/ASCII forms:

| Before | After |
|--------|-------|
| en-dash, non-breaking hyphen, figure dash | `-` |
| em-dash, horizontal bar | `--` |
| ellipsis | `...` |
| zero-width space / joiners / direction marks | *removed* |
| smart single quotes `'` `'` | `'` |
| smart double quotes `"` `"` | `"` |
| `<=`, `>=` | `<=`, `>=` |

Latin-1 characters (micro sign, non-breaking space, etc.) are left alone.

## Test plan
- [ ] Rendered output still reads naturally.
- [ ] No code semantics affected (text-only files).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)