### PR TITLE
docs: convert narrative US spellings to UK English

### DIFF
--- a/docs/CM_Compatibility_and_Versioning.adoc
+++ b/docs/CM_Compatibility_and_Versioning.adoc
@@ -85,14 +85,14 @@ For example, `chronicle-bytes` dependency is updated from `1.1.1` to `1.1.2`. +
 This rule does not apply to dependencies to the umbrella POMs which merely determine versions of other dependencies (namely, `chronicle-bom` and `third-party-bom`), if the versions of actual dependencies do not change between those versions of umbrella POMs. +
 Also, this rule does not apply to dependencies with Maven scopes of `test` or `provided`.
 
-- **bug fixes, performance optimization, or feature additions** that requires changes to:
+- **bug fixes, performance optimisation, or feature additions** that requires changes to:
 ** the binary, or serialized, form of Chronicle Map data store; therefore revising the Chronicle Map data store specification.
 ** the binary replication protocol, or the serialized form of some marshaller classes, that require creation of new versions of classes.
 
 === The <minor> number should not be updated when:
 
 - **a bug is fixed**, in a way that does not make any working code to change its behaviour semantically.
-- **performance is optimized**, changing its performance characteristics, but not semantics.
+- **performance is optimised**, changing its performance characteristics, but not semantics.
 
 During development, and after the release of the version `3.y.z`, the library should be versioned `3.y.<x+1>-SNAPSHOT`. +
 + As soon as changes are made that are substantial enough for the next released version to update the `<minor>` number, then the version should be changed to `3.<y+1>.0-SNAPSHOT`, *in the same commit operation* that these changes are made.

--- a/docs/CM_Tutorial.adoc
+++ b/docs/CM_Tutorial.adoc
@@ -625,9 +625,9 @@ So, although it is recommended that you `close()` when you have finished with th
 WARNING: If you call `close()` too early before you have finished working with the map, this can cause your JVM to crash.
 Close **MUST** be the last thing that you do with the map.
 
-== Behaviour Customization
+== Behaviour Customisation
 
-You can customize the behaviour of Chronicle Map.
+You can customise the behaviour of Chronicle Map.
 
 See <<CM_Tutorial_Behaviour.adoc#,CM_Tutorial_Behaviour>> for more details.
 

--- a/docs/CM_Tutorial_Behaviour.adoc
+++ b/docs/CM_Tutorial_Behaviour.adoc
@@ -1,4 +1,4 @@
-= Behaviour Customization
+= Behaviour Customisation
 Neil Clifford
 :toc: macro
 :toclevels: 2
@@ -8,9 +8,9 @@ Neil Clifford
 
 toc::[]
 
-== Customization
+== Customisation
 
-You could customize `ChronicleMap` behaviour on several levels:
+You could customise `ChronicleMap` behaviour on several levels:
 
 - `ChronicleMapBuilder.entryOperations()` define the "inner" listening level.
 All operations with entries, either during ordinary map method calls, remote calls, replication or modifications during iteration over the map, operate using this configured SPI.

--- a/docs/CM_Tutorial_Understanding.adoc
+++ b/docs/CM_Tutorial_Understanding.adoc
@@ -60,7 +60,7 @@ A call to the `copy()` method, at any point of a serializer instance lifetime, s
 
 As a consequence, the `copy()` method is transitive. `serializer.copy().copy().copy()` should return an object in exactly the same state as after a single `copy()` call.
 
-Chronicle Map implementation recognizes that configured `BytesWriter`, `BytesReader`, `SizedWriter`, `SizedReader`, or `DataAccess` instances implement `StatefulCopyable`, and populates it internally using `copy()` for each thread, Chronicle Map instances and serialized object domain (keys or values).
+Chronicle Map implementation recognises that configured `BytesWriter`, `BytesReader`, `SizedWriter`, `SizedReader`, or `DataAccess` instances implement `StatefulCopyable`, and populates it internally using `copy()` for each thread, Chronicle Map instances and serialized object domain (keys or values).
 
 See examples of implementing this interface in <<CM_Tutorial_Bytes.adoc#custom-charsequence-encoding,custom `CharSequence` encoding>>.
 

--- a/docs/CM_Updates.adoc
+++ b/docs/CM_Updates.adoc
@@ -16,7 +16,7 @@ Changes between Chronicle Map 3 and the previous Chronicle Map version are detai
 
 - Added support for multi-key queries.
 
-- "Listeners" mechanism fully reworked; see <<CM_Tutorial_Behaviour.adoc#,Behaviour Customization>>.
+- "Listeners" mechanism fully reworked; see <<CM_Tutorial_Behaviour.adoc#,Behaviour Customisation>>.
 This has a number of important consequences, most notable is that it is now possible to define "eventual-consistency" replication strategy, different from "last write wins"; any state-based CRDT.
 
 - "Stateless clients" functionality (remote calls) has been removed.

--- a/spec/2-design-overview.md
+++ b/spec/2-design-overview.md
@@ -121,7 +121,7 @@ A segment tier basically consists of two parts:
 
 The hash lookup slots' size is either 4 or 8 bytes. Allocation identifiers use the minimum required
 bits to identify themselves within the entry space, the rest bits of hash lookup slots are used to
-store bits of the Chronicle Map's key hash codes, to minimize full collisions on the hash lookup
+store bits of the Chronicle Map's key hash codes, to minimise full collisions on the hash lookup
 level.
 
 > Hash lookup slots are disallowed to be of any integral byte size from 3 to 8 bytes, despite it

--- a/spec/3-memory-layout.md
+++ b/spec/3-memory-layout.md
@@ -19,7 +19,7 @@ one big continuous block of memory. Its structure, from lower addresses to highe
  is read from the global mutable state (specifically this field of the global mutable state is
  actually immutable, once written).
 
- > The purpose of this alignment is to minimize the number of pages spanned by the following
+ > The purpose of this alignment is to minimise the number of pages spanned by the following
  > *segment headers area*. The segment headers area is frequently accessed and updated, so the pages
  > it spans almost always reside in the TLB cache and always need to be flushed to the disk.
 
@@ -117,7 +117,7 @@ multiples of `segmentHeaderSize`. Each segment header is 32 bytes long. `segment
  *unsigned* value, stored in the little-endian order.
  3. Bytes 12..15 - the smallest index of a chunk in the entry space of the first tier of the
  segment, that could possibly be free. A 32-bit *unsigned* value, stored in the little-endian order.
- This field is used to optimize allocation of space for new entries, the search for a sufficient
+ This field is used to optimise allocation of space for new entries, the search for a sufficient
  range of continuous free chunks in the [free list](#free-list) is started from this index, rather
  than 0. This field is updated on each entry allocation and deletion in the first tier of the
  segment, if the smallest index of a free chunk is changed. When all chunks in the entry space are

--- a/spec/3_1-header-fields.md
+++ b/spec/3_1-header-fields.md
@@ -88,7 +88,7 @@ e. g.
 >  `actualSegments` value is a power of 2 (except 1). Lowest bits of keys' hash codes (specified by
 >  the `bits` field) are used to choose the segment, highest 64 &minus; `bits` are used as keys in
 >  segment tier's hash lookups.
->  - `net.openhft.chronicle.hash.impl.HashSplitting$ForSingleSegment` is an optimized version of
+>  - `net.openhft.chronicle.hash.impl.HashSplitting$ForSingleSegment` is an optimised version of
 >  `HashSplitting$ForPowerOf2Segments`, for the case of the single segment in the Chronicle Map
 >  (`actualSegments` equals to 1). The "chosen" segment index is 0, and entire key's hash codes are
 >  used as key in segment tier's hash lookups.

--- a/spec/6-queries.md
+++ b/spec/6-queries.md
@@ -336,7 +336,7 @@ Steps 4-5 are *in-place* value update. Steps from 6 to the end of the operation 
  > Example: [`TrickyContextCasesTest.testPutShouldBeWriteLocked()`](
  > ../src/test/java/net/openhft/chronicle/map/TrickyContextCasesTest.java) method.
  >
- > Possibility to optimize this is explored in [HCOLL-425](
+ > Possibility to optimise this is explored in [HCOLL-425](
  > https://higherfrequencytrading.atlassian.net/browse/HCOLL-425).
  >
  > If a block of free chunks for the updated entry is found in a different tier from the one where

--- a/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
+++ b/src/main/java/net/openhft/chronicle/hash/ChronicleHashBuilder.java
@@ -180,7 +180,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * required by the entry, 200 bytes will be allocated, 150 used and 50 wasted. This is called
      * internal fragmentation.
      * <p>
-     * To minimize memory overuse and improve speed, you should pay decent attention to this
+     * To minimise memory overuse and improve speed, you should pay decent attention to this
      * configuration. Alternatively, you can just trust the heuristics and doesn't configure
      * the chunk size.
      * <p>
@@ -567,7 +567,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * <p>
      * <em>WARNING:</em> Make sure this instance is the only one that accesses the
      * provided {@code file} during recovery across all JVMs/threads/processes or else
-     * the behavior is unspecified including the possibility that the Map file gets
+     * the behaviour is unspecified including the possibility that the Map file gets
      * <em>completely corrupted and/or is silently returning stale or otherwise erroneous data.</em>
      * <p>
      * Chronicle Map employs a best-effort to ensure file exclusivity during recovery operations.
@@ -626,7 +626,7 @@ public interface ChronicleHashBuilder<K, H extends ChronicleHash<K, ?, ?, ?>,
      * <p>
      * <em>WARNING:</em> Make sure this instance is the only one that accesses the
      * provided {@code file} during recovery across all JVMs/threads/processes or else
-     * the behavior is unspecified including the possibility that the Map file gets
+     * the behaviour is unspecified including the possibility that the Map file gets
      * <em>completely corrupted and/or is silently returning stale or otherwise erroneous data.</em>
      * <p>
      * Chronicle Map employs a best-effort to ensure file exclusivity during recovery operations.

--- a/src/main/java/net/openhft/chronicle/hash/impl/HashSplitting.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/HashSplitting.java
@@ -83,7 +83,7 @@ public interface HashSplitting extends Marshallable {
         }
     }
 
-    //TODO optimize?
+    //TODO optimise?
     class ForNonPowerOf2Segments implements HashSplitting {
 
         private static final int MASK = Integer.MAX_VALUE;

--- a/src/main/java/net/openhft/chronicle/hash/impl/InternalMapFileAnalyzer.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/InternalMapFileAnalyzer.java
@@ -45,8 +45,8 @@ public final class InternalMapFileAnalyzer {
 
         final Path path = Paths.get(args[0]);
 
-        System.out.println("Analyzing " + path.toAbsolutePath());
-        System.out.println("Warning, this program is not capable of analyzing all map file types.");
+        System.out.println("Analysing " + path.toAbsolutePath());
+        System.out.println("Warning, this program is not capable of analysing all map file types.");
 
         if (path.toFile().length() > 1L << 31) {
             System.out.println("This program can only handle files that are smaller than 2^31 bytes)");

--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -643,7 +643,7 @@ public abstract class VanillaChronicleHash<K,
 
     private long computeSegmentHeadersOffset() {
         long reserved = RESERVED_GLOBAL_MUTABLE_STATE_BYTES - globalMutableStateTotalUsedSize();
-        // Align segment headers on page boundary to minimize number of pages that
+        // Align segment headers on page boundary to minimise number of pages that
         // segment headers span
         return pageAlign(mapHeaderInnerSize() + reserved);
     }
@@ -771,7 +771,7 @@ public abstract class VanillaChronicleHash<K,
     }
 
     public final int inChunks(final long sizeInBytes) {
-        // TODO optimize for the case when chunkSize is power of 2, that is default (and often) now
+        // TODO optimise for the case when chunkSize is power of 2, that is default (and often) now
         if (sizeInBytes <= chunkSize)
             return 1;
 

--- a/src/main/java/net/openhft/chronicle/hash/serialization/SizeMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/SizeMarshaller.java
@@ -15,7 +15,7 @@ import net.openhft.chronicle.wire.Marshallable;
  * the same bytes store). Normal number storing (4 bytes for {@code int}, 8 bytes for {@code long}
  * is rather wasteful for marshalling purposes, when the number (size) to store is usually very
  * small, and 1-2 bytes could be enough to encode it (this is how {@link #stopBit()} marshaller
- * works). Also, this interface allows to generalize storing constantly-sized and variable-sized
+ * works). Also, this interface allows to generalise storing constantly-sized and variable-sized
  * blocks of data. Constantly-sized don't require to store the size actually, the corresponding
  * {@link #constant} {@code SizeMarshaller} consumes 0 bytes.
  * <p>

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/DoubleMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/DoubleMarshaller.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * As a writer for top-level Chronicle Map's key or value type (Long), {@code DoubleMarshaller} is
- * deprecated in favor of {@link DoubleDataAccess}. As reader and element writer for {@link
+ * deprecated in favour of {@link DoubleDataAccess}. As reader and element writer for {@link
  * ListMarshaller} and similar composite marshallers, {@code DoubleMarshaller} is not deprecated.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/IntegerMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/IntegerMarshaller.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * As a writer for top-level Chronicle Map's key or value type (Integer), {@code IntegerMarshaller}
- * is deprecated in favor of {@link IntegerDataAccess_3_13}. As reader and element writer for {@link
+ * is deprecated in favour of {@link IntegerDataAccess_3_13}. As reader and element writer for {@link
  * ListMarshaller} and similar composite marshallers, {@code IntegerMarshaller} is not deprecated.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/LongMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/LongMarshaller.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * As a writer for top-level Chronicle Map's key or value type (Long), {@code LongMarshaller} is
- * deprecated in favor of {@link LongDataAccess}. As reader and element writer for {@link
+ * deprecated in favour of {@link LongDataAccess}. As reader and element writer for {@link
  * ListMarshaller} and similar composite marshallers, {@code LongMarshaller} is not deprecated.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -1079,7 +1079,7 @@ public final class ChronicleMapBuilder<K, V> implements
     //TODO review because this heuristic doesn't seem to perform well
     private int estimateSegmentsBasedOnSize() {
         // the idea is that if values are huge, operations on them (and simply ser/deser)
-        // could take long time, so we want more segment to minimize probablity that
+        // could take long time, so we want more segment to minimise probablity that
         // two or more concurrent write ops will go to the same segment, and then all but one of
         // these threads will wait for long time.
         int segmentsForEntries = estimateSegmentsForEntries(entries());

--- a/src/main/java/net/openhft/chronicle/map/MapAbsentEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/MapAbsentEntry.java
@@ -27,7 +27,7 @@ public interface MapAbsentEntry<K, V> extends HashAbsentEntry<K> {
      * value}.
      * <p>
      * This method is the default implementation for {@link MapEntryOperations#insert(
-     *MapAbsentEntry, Data)}, which might be customized over the default.
+     *MapAbsentEntry, Data)}, which might be customised over the default.
      *
      * @param value the value to insert into the map along with {@link #absentKey() the key}
      * @throws IllegalStateException if some locking/state conditions required to perform insertion
@@ -43,7 +43,7 @@ public interface MapAbsentEntry<K, V> extends HashAbsentEntry<K> {
      * <p>
      * This method if the default implementation for {@link
      * DefaultValueProvider#defaultValue(MapAbsentEntry)},
-     * which might be customized over the default.
+     * which might be customised over the default.
      *
      * @see DefaultValueProvider#defaultValue(MapAbsentEntry)
      */

--- a/src/main/java/net/openhft/chronicle/map/MapEntry.java
+++ b/src/main/java/net/openhft/chronicle/map/MapEntry.java
@@ -30,7 +30,7 @@ public interface MapEntry<K, V> extends SetEntry<K> {
      * Replaces the entry's value with the given {@code newValue}.
      * <p>
      * This method is the default implementation for {@link MapEntryOperations#replaceValue(
-     *MapEntry, Data)}, which might be customized over the default.
+     *MapEntry, Data)}, which might be customised over the default.
      *
      * @param newValue the value to be put into the map instead of the {@linkplain #value() current
      *                 value}
@@ -43,7 +43,7 @@ public interface MapEntry<K, V> extends SetEntry<K> {
      * Removes the entry from the map.
      * <p>
      * This method is the default implementation for {@link MapEntryOperations#remove(MapEntry)},
-     * which might be customized over the default.
+     * which might be customised over the default.
      */
     @Override
     void doRemove();

--- a/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
+++ b/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
@@ -28,7 +28,7 @@ class OldDeletedEntriesCleanupThread extends Thread
     private final WeakReference<ReplicatedChronicleMap<?, ?, ?>> mapRef;
     /**
      * {@code cleanupTimeout}, {@link #cleanupTimeoutUnit} and {@link #segments} are parts of the
-     * cleaned Map's state, extracted in order to minimize accesses to the map.
+     * cleaned Map's state, extracted in order to minimise accesses to the map.
      *
      * @see ChronicleHashBuilderPrivateAPI#removedEntryCleanupTimeout(long, TimeUnit)
      */

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -1014,7 +1014,7 @@ public class ReplicatedChronicleMap<K, V, R> extends VanillaChronicleMap<K, V, R
                                     "local id: " + localIdentifier);
                         }
                         // TODO currently, all entries, originating not from the current node,
-                        // are bootstrapped. This could be optimized, but requires to generate
+                        // are bootstrapped. This could be optimised, but requires to generate
                         // unique connection id, it identify two ChronicleMap instances
                         // reconnecting vs. different Map start-up
                         if (e.originIdentifier() != localIdentifier ||

--- a/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/VanillaChronicleMap.java
@@ -71,7 +71,7 @@ public class VanillaChronicleMap<K, V, R>
     // Value Data model
     Type valueClass;
     /////////////////////////////////////////////////
-    // Behavior
+    // Behaviour
     transient boolean putReturnsNull;
     transient boolean putIfAbsentUsingValue;
     transient boolean removeReturnsNull;
@@ -341,7 +341,7 @@ public class VanillaChronicleMap<K, V, R>
     @Override
     public final MapClosable acquireContext(@NotNull final K key, @NotNull final V usingValue) {
         final QueryContextInterface<K, V, R> q = queryContext(key);
-        // TODO optimize to update lock in certain cases
+        // TODO optimise to update lock in certain cases
         try {
             q.writeLock().lock();
             checkAcquiredUsing(acquireUsingBody(q, usingValue), usingValue);

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/data/DummyValueZeroData.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/data/DummyValueZeroData.java
@@ -59,7 +59,7 @@ public class DummyValueZeroData<V> extends AbstractData<V> {
     @Override
     public V get() {
         checkOnEachPublicOperation.checkOnEachPublicOperation();
-        // Not optimized and creates garbage, because this isn't the primary
+        // Not optimised and creates garbage, because this isn't the primary
         // use case. Zero data should only be used in bytes form
         return getUsing(null);
     }

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/entry/MapEntryStages.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/entry/MapEntryStages.java
@@ -84,7 +84,7 @@ public abstract class MapEntryStages<K, V> extends HashEntryStages<K>
         // the off-heap bytes. This condition avoids in-place data copy.
         // TODO would be nice to reduce scope of this check, i. e. check only when it could be
         // true, and avoid when it surely false (fresh value put, relocating put etc.)
-        // TODO this optimization is now disabled, because it calls value.bytes() that forces double
+        // TODO this optimisation is now disabled, because it calls value.bytes() that forces double
         // data copy, if sizedReader/Writer configured for the value.
 //        RandomDataInput valueBytes = value.bytes();
 //        if (valueBytes instanceof NativeBytesStore &&

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/ReplicatedChronicleMapHolderImpl.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/ReplicatedChronicleMapHolderImpl.java
@@ -38,7 +38,7 @@ public abstract class ReplicatedChronicleMapHolderImpl<K, V, R>
         // alternative to this "unsafe" casting approach is proper generalization
         // of Chaining/ChainingInterface, but this causes issues with current version
         // of stage-compiler.
-        // TODO generalize Chaining with <M extends VanillaCM> when stage-compiler is improved.
+        // TODO generalise Chaining with <M extends VanillaCM> when stage-compiler is improved.
         //noinspection unchecked
         m = (ReplicatedChronicleMap<K, V, R>) map;
     }

--- a/src/main/java/net/openhft/chronicle/map/impl/stage/map/VanillaChronicleMapHolderImpl.java
+++ b/src/main/java/net/openhft/chronicle/map/impl/stage/map/VanillaChronicleMapHolderImpl.java
@@ -37,7 +37,7 @@ public abstract class VanillaChronicleMapHolderImpl<K, V, R>
         // alternative to this "unsafe" casting approach is proper generalization
         // of Chaining/ChainingInterface, but this causes issues with current version
         // of stage-compiler.
-        // TODO generalize Chaining with <M extends VanillaCM> when stage-compiler is improved.
+        // TODO generalise Chaining with <M extends VanillaCM> when stage-compiler is improved.
         //noinspection unchecked
         m = map;
     }

--- a/src/main/java/net/openhft/chronicle/set/SetAbsentEntry.java
+++ b/src/main/java/net/openhft/chronicle/set/SetAbsentEntry.java
@@ -23,7 +23,7 @@ public interface SetAbsentEntry<K> extends HashAbsentEntry<K> {
      * Inserts {@link #absentKey() the new key} into the set.
      * <p>
      * This method is the default implementation for {@link SetEntryOperations#insert(
-     *SetAbsentEntry)}, which might be customized over the default.
+     *SetAbsentEntry)}, which might be customised over the default.
      *
      * @throws IllegalStateException if some locking/state conditions required to perform insertion
      *                               operation are not met

--- a/src/main/java/net/openhft/chronicle/set/SetEntry.java
+++ b/src/main/java/net/openhft/chronicle/set/SetEntry.java
@@ -20,7 +20,7 @@ public interface SetEntry<K> extends HashEntry<K> {
      * Removes the entry from the {@code ChronicleSet}.
      * <p>
      * This method is the default implementation for {@link SetEntryOperations#remove(SetEntry)},
-     * which might be customized over the default.
+     * which might be customised over the default.
      */
     @Override
     void doRemove();


### PR DESCRIPTION
## Summary
Documentation uses UK English for narrative text. Standard US technical terms (`synchronization`, `serialization`, `initialization`, `finalize`, `deserialize`, `normalization`) are preserved because that is how they appear in the Java platform and wider ecosystem.

Changes:
- `-or` -> `-our`: behavior, color, favor, flavor, honor, labor, neighbor, endeavor
- `-ize` -> `-ise` for non-technical verbs: organize, recognize, realize, optimize, minimize, maximize, emphasize, utilize, summarize, customize, prioritize, generalize, analyze

Proper nouns (e.g. "Apache License") and third-party paths (e.g. `jsr166/`) are left alone.

Review note:
- This branch also updates two user-facing CLI strings in `InternalMapFileAnalyzer` (`Analyzing` -> `Analysing`, `analyzing` -> `analysing`).
- No logic changes.

## Test plan
- [ ] Diff shows only spelling/text swaps, including the two CLI strings above.
- [ ] No API or identifier names affected.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)