### PR TITLE
Update JsonSerializer dependency guidance and pin it with docstring drift tests

### DIFF
--- a/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
+++ b/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
@@ -27,14 +27,14 @@ final class JsonSerializer {
                     "we don't include these artifacts by default as some users don't require this functionality. " +
                     "Please add the following artifacts to your project\n" +
                     "<dependency>\n" +
-                    " <groupId>xstream</groupId>\n" +
+                    " <groupId>com.thoughtworks.xstream</groupId>\n" +
                     " <artifactId>xstream</artifactId>\n" +
-                    " <version>1.2.2</version>\n" +
+                    " <version>1.4.21</version>\n" +
                     "</dependency>\n" +
                     "<dependency>\n" +
                     " <groupId>org.codehaus.jettison</groupId>\n" +
                     " <artifactId>jettison</artifactId>\n" +
-                    " <version>1.3.6</version>\n" +
+                    " <version>1.5.4</version>\n" +
                     "</dependency>\n";
 
     static synchronized <K, V> void getAll(final File toFile,

--- a/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
+++ b/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
@@ -29,7 +29,7 @@ final class JsonSerializer {
                     "<dependency>\n" +
                     " <groupId>com.thoughtworks.xstream</groupId>\n" +
                     " <artifactId>xstream</artifactId>\n" +
-                    " <version>1.4.21</version>\n" +
+                    " <version>1.4.20</version>\n" +
                     "</dependency>\n" +
                     "<dependency>\n" +
                     " <groupId>org.codehaus.jettison</groupId>\n" +

--- a/src/test/java/net/openhft/chronicle/map/JsonSerializerDocstringTest.java
+++ b/src/test/java/net/openhft/chronicle/map/JsonSerializerDocstringTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
  * Pins the dependency versions advertised in
  * {@link JsonSerializer#LOG_ERROR_SUGGEST_X_STREAM} to the actual versions
  * resolved on the test classpath.
- *
+ * <p>
  * The error message is a documented contract: anyone hitting it copies the
  * snippet straight into their {@code pom.xml}. If the BOM bumps xstream or
  * jettison and this docstring is not kept in sync, users would be advised to

--- a/src/test/java/net/openhft/chronicle/map/JsonSerializerDocstringTest.java
+++ b/src/test/java/net/openhft/chronicle/map/JsonSerializerDocstringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.map;
 

--- a/src/test/java/net/openhft/chronicle/map/JsonSerializerDocstringTest.java
+++ b/src/test/java/net/openhft/chronicle/map/JsonSerializerDocstringTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.map;
+
+import com.thoughtworks.xstream.XStream;
+import org.codehaus.jettison.mapped.MappedXMLStreamReader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins the dependency versions advertised in
+ * {@link JsonSerializer#LOG_ERROR_SUGGEST_X_STREAM} to the actual versions
+ * resolved on the test classpath.
+ *
+ * The error message is a documented contract: anyone hitting it copies the
+ * snippet straight into their {@code pom.xml}. If the BOM bumps xstream or
+ * jettison and this docstring is not kept in sync, users would be advised to
+ * pin a stale (potentially vulnerable) version. These tests fail loudly on
+ * such drift.
+ */
+public class JsonSerializerDocstringTest {
+
+    private static final Pattern XSTREAM_VERSION =
+            Pattern.compile("xstream</artifactId>\\s*<version>([^<]+)</version>");
+    private static final Pattern JETTISON_VERSION =
+            Pattern.compile("jettison</artifactId>\\s*<version>([^<]+)</version>");
+
+    private static String docstring() throws Exception {
+        Field f = JsonSerializer.class.getDeclaredField("LOG_ERROR_SUGGEST_X_STREAM");
+        f.setAccessible(true);
+        assertTrue("docstring constant should be static",
+                Modifier.isStatic(f.getModifiers()));
+        Object v = f.get(null);
+        assertNotNull(v);
+        return v.toString();
+    }
+
+    @Test
+    public void xstreamVersionInDocstringMatchesClasspath() throws Exception {
+        String advertised = extract(XSTREAM_VERSION, docstring());
+        // XStream exposes its version as a public static field.
+        String actual = XStream.class.getPackage().getImplementationVersion();
+        if (actual == null) {
+            // Fall back to xstream's META-INF / pom.properties when running
+            // from an exploded build where Implementation-Version is absent.
+            actual = readPomPropertiesVersion(
+                    XStream.class,
+                    "META-INF/maven/com.thoughtworks.xstream/xstream/pom.properties");
+        }
+        assertNotNull("could not determine xstream classpath version", actual);
+        assertEquals("docstring xstream version drifted from classpath",
+                actual, advertised);
+    }
+
+    @Test
+    public void jettisonVersionInDocstringMatchesClasspath() throws Exception {
+        String advertised = extract(JETTISON_VERSION, docstring());
+        String actual = MappedXMLStreamReader.class.getPackage().getImplementationVersion();
+        if (actual == null) {
+            actual = readPomPropertiesVersion(
+                    MappedXMLStreamReader.class,
+                    "META-INF/maven/org.codehaus.jettison/jettison/pom.properties");
+        }
+        assertNotNull("could not determine jettison classpath version", actual);
+        assertEquals("docstring jettison version drifted from classpath. "
+                        + "JsonSerializer.LOG_ERROR_SUGGEST_X_STREAM tells users to "
+                        + "pin " + advertised + " but the classpath resolves to " + actual,
+                actual, advertised);
+    }
+
+    @Test
+    public void xstreamGroupIdIsCorrectInDocstring() throws Exception {
+        String s = docstring();
+        assertTrue("docstring must reference the correct xstream groupId; "
+                        + "the original snippet had a bare 'xstream' which is wrong: " + s,
+                s.contains("<groupId>com.thoughtworks.xstream</groupId>"));
+    }
+
+    private static String extract(Pattern p, String haystack) {
+        Matcher m = p.matcher(haystack);
+        assertTrue("pattern " + p + " did not match docstring: " + haystack, m.find());
+        return m.group(1).trim();
+    }
+
+    private static String readPomPropertiesVersion(Class<?> c, String resource)
+            throws IOException {
+        try (InputStream in = c.getClassLoader().getResourceAsStream(resource)) {
+            if (in == null) return null;
+            Properties p = new Properties();
+            p.load(in);
+            return p.getProperty("version");
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the optional JSON serializer dependency snippet emitted by `JsonSerializer` when XStream/Jettison are missing.

## What changed

* Corrected the XStream Maven coordinates:

  * `xstream:xstream` → `com.thoughtworks.xstream:xstream`
* Updated advertised optional dependency versions:

  * XStream `1.2.2` → `1.4.20`
  * Jettison `1.3.6` → `1.5.4`
* Added `JsonSerializerDocstringTest` to ensure the error-message dependency snippet stays aligned with the versions resolved on the test classpath.
* Added a regression check that the XStream groupId remains the correct `com.thoughtworks.xstream`.

## Why

`JsonSerializer.LOG_ERROR_SUGGEST_X_STREAM` is effectively user-facing documentation: users who hit this path are likely to copy the suggested Maven snippet directly into their `pom.xml`.

The old snippet referenced stale dependency versions and an incorrect XStream groupId, which could lead users to pin obsolete or vulnerable transitive dependencies.

The new tests make this guidance fail fast if the project BOM or dependency management changes without updating the message.
