### PR TITLE
[codex] Update xstream docstring version

### DIFF
--- a/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
+++ b/src/main/java/net/openhft/chronicle/map/JsonSerializer.java
@@ -30,7 +30,7 @@ final class JsonSerializer {
                     "<dependency>\n" +
                     " <groupId>com.thoughtworks.xstream</groupId>\n" +
                     " <artifactId>xstream</artifactId>\n" +
-                    " <version>1.4.20</version>\n" +
+                    " <version>1.4.21</version>\n" +
                     "</dependency>\n" +
                     "<dependency>\n" +
                     " <groupId>org.codehaus.jettison</groupId>\n" +


### PR DESCRIPTION
## What changed

Updated `JsonSerializer.LOG_ERROR_SUGGEST_X_STREAM` so the advertised XStream dependency version is `1.4.21`.

## Why

`develop` already bumped the Chronicle Map POM to XStream `1.4.21`, but the runtime error message still told users to copy a dependency snippet pinned to `1.4.20`.

## Root cause

The dependency version bump and the user-facing JSON serializer dependency snippet drifted apart, which caused `JsonSerializerDocstringTest.xstreamVersionInDocstringMatchesClasspath` to fail in the Java 11 builds.

## Validation

Ran under Java 11:

```bash
mvn -q -Dtest=JsonSerializerDocstringTest test -l logs/jsonserializer-docstring-java11.log
```