### PR TITLE
[#310] Background cleanup of removed entries is disabled even if ChronicleMapBuilder#cleanupRemovedEntries is true

### DIFF
--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -2036,6 +2036,7 @@ public final class ChronicleMapBuilder<K, V> implements
 
     private void establishCleanupThread(@NotNull final ReplicatedChronicleMap map) {
         final OldDeletedEntriesCleanupThread cleanupThread = new OldDeletedEntriesCleanupThread(map);
+        map.oldDeletedEntriesCleanupThread(cleanupThread);
         map.addCloseable(cleanupThread);
         cleanupThread.start();
     }

--- a/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
+++ b/src/main/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupThread.java
@@ -6,6 +6,7 @@ package net.openhft.chronicle.map;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.hash.ChronicleHashBuilderPrivateAPI;
 import net.openhft.chronicle.hash.ReplicatedHashSegmentContext;
+import net.openhft.chronicle.hash.impl.BigSegmentHeader;
 import net.openhft.chronicle.hash.replication.ReplicableEntry;
 
 import java.lang.ref.WeakReference;
@@ -44,11 +45,11 @@ class OldDeletedEntriesCleanupThread extends Thread
     private final int[] inverseSegmentsPermutation;
 
     /**
-     * This object is used to determine that this thread is parked from {@link #sleepMillis(long)}
-     * or {@link #sleepNanos(long)}, not somewhere inside ChronicleMap logic, to interrupt()
-     * selectively in {@link #close()}.
+     * Identifies parks performed by {@link #sleepMillis(long)} and {@link #sleepNanos(long)} in
+     * thread dumps and diagnostics.
      */
     private final Object cleanupSleepingHandle = new Object();
+    private final long closeJoinTimeoutNanos;
 
     private volatile boolean shutdown;
 
@@ -57,15 +58,31 @@ class OldDeletedEntriesCleanupThread extends Thread
     private final long startTime = System.currentTimeMillis();
 
     OldDeletedEntriesCleanupThread(ReplicatedChronicleMap<?, ?, ?> map) {
+        this(map, defaultCloseJoinTimeoutNanos(), TimeUnit.NANOSECONDS);
+    }
+
+    OldDeletedEntriesCleanupThread(ReplicatedChronicleMap<?, ?, ?> map,
+                                   long closeJoinTimeout,
+                                   TimeUnit closeJoinTimeoutUnit) {
         super("Cleanup Thread for " + map.toIdentityString());
+        if (closeJoinTimeout <= 0)
+            throw new IllegalArgumentException("closeJoinTimeout must be positive");
         setDaemon(true);
         this.mapRef = new WeakReference<>(map);
+        this.closeJoinTimeoutNanos = closeJoinTimeoutUnit.toNanos(closeJoinTimeout);
         cleanupTimeout = map.cleanupTimeout;
         cleanupTimeoutUnit = map.cleanupTimeoutUnit;
         segments = map.segments();
 
         segmentsPermutation = randomPermutation(map.segments());
         inverseSegmentsPermutation = inversePermutation(segmentsPermutation);
+    }
+
+    private static long defaultCloseJoinTimeoutNanos() {
+        // A cleaner already waiting for a segment lock uses this timeout. Give that acquisition a
+        // chance to report its own dead-lock failure, then stop waiting rather than hanging close.
+        final long lockTimeoutSeconds = Math.max(0L, BigSegmentHeader.LOCK_TIMEOUT_SECONDS);
+        return TimeUnit.SECONDS.toNanos(lockTimeoutSeconds + 1L);
     }
 
     private static int[] randomPermutation(int n) {
@@ -101,8 +118,15 @@ class OldDeletedEntriesCleanupThread extends Thread
     public void run() {
         throwExceptionIfClosed();
 
-        if (System.currentTimeMillis() - startTime < 1_000)
-            return;
+        // Delay the first cleanup pass by up to a second after construction (see "delayed cleaner").
+        // Historically this exited the thread outright when less than a second had elapsed, which -
+        // because the thread is started immediately after construction - meant the cleanup thread
+        // almost always terminated before removing a single old deleted entry, so tombstones were
+        // only ever reclaimed as a side effect of a later put()/replication event on the segment.
+        // Wait out the remaining delay instead, respecting shutdown, then run the cleanup loop.
+        long remainingStartupDelay = 1_000 - (System.currentTimeMillis() - startTime);
+        if (remainingStartupDelay > 0)
+            sleepMillis(remainingStartupDelay);
 
         while (!shutdown) {
             int nextSegmentIndex;
@@ -184,18 +208,42 @@ class OldDeletedEntriesCleanupThread extends Thread
             LockSupport.parkUntil(cleanupSleepingHandle, deadline);
     }
 
-    private void sleepNanos(long nanos) {
+    void sleepNanos(long nanos) {
         long deadline = System.nanoTime() + nanos;
-        while (System.nanoTime() < deadline && !shutdown)
-            LockSupport.parkNanos(cleanupSleepingHandle, deadline);
+        long remaining;
+        while ((remaining = deadline - System.nanoTime()) > 0 && !shutdown)
+            LockSupport.parkNanos(cleanupSleepingHandle, remaining);
     }
 
     @Override
     public void close() {
         shutdown = true;
-        // this means blocked in sleepMillis() or sleepNanos()
-        if (LockSupport.getBlocker(this) == cleanupSleepingHandle)
-            this.interrupt(); // unblock
+        // Unblock both our explicit sleeps and a segment-lock wait. Map resources, including the
+        // thread's iteration context, must not be released until run() has finished.
+        interrupt();
+        if (Thread.currentThread() == this)
+            return;
+
+        boolean interrupted = false;
+        final long deadline = System.nanoTime() + closeJoinTimeoutNanos;
+        while (isAlive()) {
+            final long remaining = deadline - System.nanoTime();
+            if (remaining <= 0) {
+                if (interrupted)
+                    Thread.currentThread().interrupt();
+                throw new IllegalStateException(
+                        "Cleanup thread did not stop within " +
+                                TimeUnit.NANOSECONDS.toMillis(closeJoinTimeoutNanos) +
+                                " milliseconds; Chronicle Map resources have not been released");
+            }
+            try {
+                TimeUnit.NANOSECONDS.timedJoin(this, remaining);
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted)
+            Thread.currentThread().interrupt();
     }
 
     private int nextSegmentIndex(int segmentIndex) {

--- a/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
+++ b/src/main/java/net/openhft/chronicle/map/ReplicatedChronicleMap.java
@@ -97,6 +97,7 @@ public class ReplicatedChronicleMap<K, V, R> extends VanillaChronicleMap<K, V, R
     public transient boolean cleanupRemovedEntries;
     public transient long cleanupTimeout;
     public transient TimeUnit cleanupTimeoutUnit;
+    private transient OldDeletedEntriesCleanupThread oldDeletedEntriesCleanupThread;
     public transient MapRemoteOperations<K, V, R> remoteOperations;
     transient BitSetFrame tierModIterFrame;
     private long tierModIterBitSetSizeInBits;
@@ -216,6 +217,20 @@ public class ReplicatedChronicleMap<K, V, R> extends VanillaChronicleMap<K, V, R
         cleanupRemovedEntries = builder.cleanupRemovedEntries;
         cleanupTimeout = builder.cleanupTimeout;
         cleanupTimeoutUnit = builder.cleanupTimeoutUnit;
+    }
+
+    void oldDeletedEntriesCleanupThread(OldDeletedEntriesCleanupThread cleanupThread) {
+        this.oldDeletedEntriesCleanupThread = cleanupThread;
+    }
+
+    @Override
+    protected void assertCloseable() {
+        // The cleaner owns a Chronicle Map iteration context. Stop it before the base close path
+        // inspects and closes contexts; otherwise close can race an in-progress segment scan and
+        // release or mutate the cleaner's context underneath it.
+        if (oldDeletedEntriesCleanupThread != null)
+            oldDeletedEntriesCleanupThread.close();
+        super.assertCloseable();
     }
 
     private long computeTierModIterBitSetSizeInBits() {

--- a/src/test/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupTest.java
+++ b/src/test/java/net/openhft/chronicle/map/OldDeletedEntriesCleanupTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.map;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.hash.ChronicleHashBuilderPrivateAPI;
+import net.openhft.chronicle.hash.ReplicatedHashSegmentContext;
+import net.openhft.chronicle.hash.SegmentLock;
+import org.junit.Test;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for Chronicle-Map#310.
+ *
+ * <p>A removed entry in a replicated map leaves a tombstone (an absent replicable entry) so the
+ * deletion can propagate. Those tombstones are reclaimed in the background by
+ * {@link OldDeletedEntriesCleanupThread} once {@code removedEntryCleanupTimeout} has elapsed - this
+ * must happen on its own, without any later {@code put()}/query touching the segment.
+ *
+ * <p>Before the fix, {@code run()} exited the cleanup thread outright whenever less than a second
+ * had elapsed since construction. Because the thread is started immediately after construction, it
+ * almost always terminated before removing a single entry, so tombstones were only ever reclaimed
+ * as a side effect of a later operation on the same slot. This test creates tombstones, then waits
+ * (doing nothing else to the map) for the background thread to clear them.
+ */
+public class OldDeletedEntriesCleanupTest {
+
+    @Test(timeout = 30_000)
+    public void tombstonesAreClearedByBackgroundCleanupWithoutLaterPut() {
+        final ChronicleMapBuilder<Integer, CharSequence> builder = replicatedBuilder(
+                1, TimeUnit.MILLISECONDS);
+
+        try (ChronicleMap<Integer, CharSequence> map = builder.create()) {
+            for (int i = 1; i <= 5; i++)
+                map.put(i, "value-" + i);
+            for (int i = 1; i <= 5; i++)
+                map.remove(i);
+
+            assertEquals(0, map.size());
+            // The removals leave tombstones behind - replicable entries still occupy the segment.
+            assertTrue("expected tombstones to be present right after removal",
+                    countReplicableEntries(map) > 0);
+
+            // Wait for the background cleanup thread to erase the tombstones. Crucially we perform
+            // NO further map operations here: the entries must be reclaimed by the thread itself.
+            final long deadline = System.currentTimeMillis() + 25_000;
+            while (countReplicableEntries(map) > 0 && System.currentTimeMillis() < deadline)
+                Jvm.pause(50);
+
+            assertEquals("background cleanup should have erased all tombstones without a later put",
+                    0, countReplicableEntries(map));
+        }
+    }
+
+    /**
+     * A microsecond-based timeout exercises the cleaner's sub-millisecond wait path. Two tombstone
+     * batches are created on opposite sides of a completed cleanup pass so the second batch can
+     * only disappear if the cleaner wakes and performs another cycle.
+     */
+    @Test(timeout = 30_000)
+    public void microsecondTimeoutCleansAcrossMultipleCycles() {
+        try (ChronicleMap<Integer, CharSequence> map = replicatedBuilder(
+                1_500, TimeUnit.MICROSECONDS).create()) {
+            removeAndAwaitCleanup(map, 1);
+            removeAndAwaitCleanup(map, 2);
+        }
+    }
+
+    /**
+     * {@link java.util.concurrent.locks.LockSupport#parkNanos(Object, long)} accepts a relative
+     * duration. Passing an absolute {@link System#nanoTime()} deadline parks effectively forever.
+     */
+    @Test(timeout = 10_000)
+    public void nanosecondSleepUsesRelativeDuration() throws InterruptedException {
+        try (ChronicleMap<Integer, CharSequence> map = replicatedBuilder(
+                1_500, TimeUnit.MICROSECONDS).create()) {
+            final OldDeletedEntriesCleanupThread cleaner = cleanupThread(map);
+            final Thread sleeper = new Thread(
+                    () -> cleaner.sleepNanos(TimeUnit.MICROSECONDS.toNanos(500)),
+                    "cleanup-nanos-regression");
+            sleeper.start();
+            sleeper.join(2_000);
+            try {
+                assertFalse("a 0.5 ms relative wait must not remain parked for seconds",
+                        sleeper.isAlive());
+            } finally {
+                sleeper.interrupt();
+                sleeper.join(2_000);
+            }
+        }
+    }
+
+    /**
+     * Closing a replicated map must stop the cleaner before the base close path releases its
+     * registered iteration context. This test holds the cleaner's segment lock, starts close, and
+     * interrupts the closing thread while it joins. Releasing the lock must let both cleaner and
+     * close finish, with the closing thread's interrupt status restored.
+     */
+    @Test(timeout = 30_000)
+    public void closeWaitsForCleanerAndRestoresInterruptStatus() throws InterruptedException {
+        final ChronicleMap<Integer, CharSequence> map = replicatedBuilder(
+                1, TimeUnit.MILLISECONDS).create();
+        final MapSegmentContext<Integer, CharSequence, ?> context = map.segmentContext(0);
+        final SegmentLock segmentLock = (SegmentLock) context;
+        final OldDeletedEntriesCleanupThread cleaner = cleanupThread(map);
+        final AtomicReference<Throwable> closeFailure = new AtomicReference<>();
+        final AtomicBoolean interruptRestored = new AtomicBoolean();
+        final Thread closer = new Thread(() -> {
+            try {
+                map.close();
+                interruptRestored.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable t) {
+                closeFailure.set(t);
+            }
+        }, "map-close-regression");
+
+        segmentLock.updateLock().lock();
+        try {
+            awaitSegmentLockAcquisition(cleaner);
+
+            closer.start();
+            final long shutdownDeadline = System.currentTimeMillis() + 5_000;
+            while (!closer.isAlive() && System.currentTimeMillis() < shutdownDeadline)
+                Jvm.pause(10);
+            closer.interrupt();
+            Jvm.pause(100);
+
+            assertTrue("close must wait while the cleaner owns or awaits its segment context",
+                    closer.isAlive());
+            assertTrue("cleaner must still be alive while its segment lock is held",
+                    cleaner.isAlive());
+        } finally {
+            segmentLock.updateLock().unlock();
+            context.close();
+        }
+
+        closer.join(5_000);
+        assertFalse("map.close() must complete within its bounded cleaner join", closer.isAlive());
+        assertFalse("cleaner must exit before map.close() returns", cleaner.isAlive());
+        assertNull("map.close() should not fail once the cleaner's lock is released",
+                closeFailure.get());
+        assertTrue("interrupt status must be restored after the join completes",
+                interruptRestored.get());
+        assertTrue(map.isClosed());
+    }
+
+    @Test(timeout = 30_000)
+    public void closeFailsWithinConfiguredDeadlineWhenCleanerCannotLeaveSegmentLockWait()
+            throws InterruptedException {
+        final ChronicleMapBuilder<Integer, CharSequence> builder = replicatedBuilder(
+                1, TimeUnit.MILLISECONDS);
+        final ChronicleHashBuilderPrivateAPI<?, ?> privateAPI =
+                Objects.requireNonNull(Jvm.getValue(builder, "privateAPI"));
+        privateAPI.cleanupRemovedEntries(false);
+
+        final ChronicleMap<Integer, CharSequence> map = builder.create();
+        final MapSegmentContext<Integer, CharSequence, ?> context = map.segmentContext(0);
+        final SegmentLock segmentLock = (SegmentLock) context;
+        final OldDeletedEntriesCleanupThread cleaner = new OldDeletedEntriesCleanupThread(
+                (ReplicatedChronicleMap<?, ?, ?>) map, 100, TimeUnit.MILLISECONDS);
+
+        segmentLock.updateLock().lock();
+        try {
+            cleaner.start();
+            awaitSegmentLockAcquisition(cleaner);
+            final long start = System.nanoTime();
+            try {
+                cleaner.close();
+                fail("close should fail rather than release resources under a live cleaner");
+            } catch (IllegalStateException expected) {
+                final long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(
+                        System.nanoTime() - start);
+                assertTrue("configured close deadline should be observed", elapsedMillis >= 75);
+                assertTrue("close deadline must remain bounded", elapsedMillis < 2_000);
+                assertTrue(expected.getMessage().contains("resources have not been released"));
+                assertTrue("cleaner is deliberately still alive at timeout", cleaner.isAlive());
+            }
+        } finally {
+            segmentLock.updateLock().unlock();
+            context.close();
+        }
+
+        cleaner.join(5_000);
+        assertFalse("cleaner must exit after the segment lock is released", cleaner.isAlive());
+        map.close();
+    }
+
+    private static ChronicleMapBuilder<Integer, CharSequence> replicatedBuilder(
+            long cleanupTimeout, TimeUnit unit) {
+        final ChronicleMapBuilder<Integer, CharSequence> builder = ChronicleMap
+                .of(Integer.class, CharSequence.class)
+                .entries(1000)
+                .averageValueSize(20)
+                .actualSegments(1);
+
+        final ChronicleHashBuilderPrivateAPI<?, ?> privateAPI =
+                Objects.requireNonNull(Jvm.getValue(builder, "privateAPI"));
+        privateAPI.replication((byte) 1);
+        privateAPI.removedEntryCleanupTimeout(cleanupTimeout, unit);
+        return builder;
+    }
+
+    private static void removeAndAwaitCleanup(
+            ChronicleMap<Integer, CharSequence> map, int key) {
+        map.put(key, "value-" + key);
+        map.remove(key);
+        assertTrue("expected a tombstone immediately after removal",
+                countReplicableEntries(map) > 0);
+
+        final long deadline = System.currentTimeMillis() + 10_000;
+        while (countReplicableEntries(map) > 0 && System.currentTimeMillis() < deadline)
+            Jvm.pause(10);
+        assertEquals("background cleanup should complete this tombstone batch",
+                0, countReplicableEntries(map));
+    }
+
+    private static OldDeletedEntriesCleanupThread cleanupThread(
+            ChronicleMap<Integer, CharSequence> map) {
+        return Objects.requireNonNull(Jvm.getValue(map, "oldDeletedEntriesCleanupThread"));
+    }
+
+    private static void awaitSegmentLockAcquisition(Thread cleaner) {
+        final long deadline = System.currentTimeMillis() + 10_000;
+        while (!isAcquiringSegmentLock(cleaner) && System.currentTimeMillis() < deadline)
+            Jvm.pause(10);
+        assertTrue("cleaner must reach segment-lock acquisition, not merely its startup sleep",
+                isAcquiringSegmentLock(cleaner));
+    }
+
+    private static boolean isAcquiringSegmentLock(Thread cleaner) {
+        for (StackTraceElement frame : cleaner.getStackTrace()) {
+            if (frame.getClassName().endsWith("UpdateLock") &&
+                    frame.getMethodName().equals("lock"))
+                return true;
+        }
+        return false;
+    }
+
+    private static int countReplicableEntries(ChronicleMap<Integer, CharSequence> map) {
+        final int[] count = {0};
+        for (int i = 0; i < map.segments(); i++) {
+            try (MapSegmentContext<Integer, CharSequence, ?> context = map.segmentContext(i)) {
+                ((ReplicatedHashSegmentContext<Integer, ?>) context)
+                        .forEachSegmentReplicableEntry(e -> count[0]++);
+            }
+        }
+        return count[0];
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `ec649062438ef6f706a493945608d44dbb3df3dc` into the existing branch with normal forward commits. Updated head: `da993d9e8342d8c86bf3313c27419889c1802dd6`. Both develop `ec649062438ef6f706a493945608d44dbb3df3dc` and the declared parent are ancestors of this head; both missing-commit counts are zero.

Retained current persisted-header and worker-failure fixes. Full clean verify passed on Java 21: 1,330 reported tests, 82 skipped, including cleanup-worker lifecycle coverage.

Supported-platform execution and consumer compatibility remain merge gates.

Local runs used Linux x86-64 and OpenJDK 21.0.12 unless Java 8 is explicitly stated (8u502). Reported test counts include skips. Commands requested zero Surefire reruns. Draft status and declared target are retained.

Earlier implementation/review notes follow. Earlier validation and performance claims apply only to their stated revisions and are superseded by the current receipt above where they differ.

---

## What changed

The removed-entry cleanup thread no longer exits before doing work, and map close now interrupts and joins that thread before the base close path inspects or releases map contexts. Head: `12287ca6`.

## Why

Activating the previously dormant thread exposed a lifecycle race: close could release the cleanup thread's iteration context during a segment scan, causing cleanup lock errors and `MemoryLeaksTest` null dereferences. The thread must stop before context teardown.

## Impact

Configured tombstone cleanup runs, while explicit close and cleaner-based resource release retain their existing safety guarantees.

## Review status

**Draft — coherent local fix, awaiting maintainer review.**

## Validation

- `mvn -o -B -Dtest=OldDeletedEntriesCleanupTest,MemoryLeaksTest -Dsurefire.failIfNoSpecifiedTests=false test`: 17 tests passed.
- `mvn -o -B clean test`: 1,317 tests, 82 skipped, no failures/errors at `12287ca6` in 1:36.
- `git diff --check`: passed.
- Remote CI and maintainer review remain required.

## Tracking

Fixes #310.
