### PR TITLE
[#462] size of ObjectOutputStream is not equal when two Maps are equal

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializationBuilder.java
+++ b/src/main/java/net/openhft/chronicle/hash/serialization/impl/SerializationBuilder.java
@@ -29,6 +29,7 @@ public final class SerializationBuilder<T> implements Cloneable {
     private SizeMarshaller sizeMarshaller = stopBit();
     private SizedReader<T> reader;
     private DataAccess<T> dataAccess;
+    private boolean defaultJavaSerialization;
 
     @SuppressWarnings("unchecked")
     public SerializationBuilder(Class<T> tClass) {
@@ -123,6 +124,7 @@ public final class SerializationBuilder<T> implements Cloneable {
         } else {
             reader((SizedReader<T>) new SerializableReader<>());
             dataAccess((DataAccess<T>) new SerializableDataAccess<>());
+            defaultJavaSerialization = true;
         }
     }
 
@@ -152,10 +154,25 @@ public final class SerializationBuilder<T> implements Cloneable {
     public void dataAccess(DataAccess<T> dataAccess) {
         checkNonMarshallableEnum(dataAccess.getClass());
         this.dataAccess = dataAccess;
+        defaultJavaSerialization = false;
     }
 
     public DataAccess<T> dataAccess() {
         return dataAccess.copy();
+    }
+
+    /**
+     * Returns {@code true} if this type falls back to default Java serialization (the {@link
+     * SerializableDataAccess} chosen when no more specific marshaller applies and the user has not
+     * configured a custom {@link DataAccess}). Such a serialized form is not guaranteed to be
+     * canonical: object graph sharing, collection ordering, or fields ignored by {@code equals()}
+     * can make equal objects serialize to differing bytes. This is used at builder time to detect
+     * risky key types - see Chronicle-Map issue #462. An explicitly configured {@code DataAccess}
+     * is not inspected or certified as canonical; its byte-identity contract remains the caller's
+     * responsibility.
+     */
+    public boolean usesDefaultJavaSerialization() {
+        return defaultJavaSerialization;
     }
 
     public void writer(SizedWriter<? super T> writer) {

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -152,7 +152,6 @@ public final class ChronicleMapBuilder<K, V> implements
     private static final int MAX_BOOTSTRAPPING_HEADER_SIZE = (int) MemoryUnit.KILOBYTES.toBytes(16);
     private static final boolean MAP_CREATION_DEBUG = Jvm.getBoolean("chronicle.map.creation.debug");
     private static final int FILE_LOCK_TIMEOUT = Jvm.getInteger("chronicle.map.file.lock.timeout.secs", 10);
-
     SerializationBuilder<K> keyBuilder;
     SerializationBuilder<V> valueBuilder;
     K averageKey;
@@ -206,6 +205,8 @@ public final class ChronicleMapBuilder<K, V> implements
     private boolean persisted;
     private String replicatedMapClassName = ReplicatedChronicleMap.class.getName();
     private boolean sparseFile = Jvm.getBoolean("chronicle.map.sparseFile");
+    private boolean strictSerializedKeyIdentity =
+            Jvm.getBoolean("chronicle.map.strictSerializedKeyIdentity");
 
     ChronicleMapBuilder(@NotNull final Class<K> keyClass, @NotNull final Class<V> valueClass) {
         keyBuilder = new SerializationBuilder<>(keyClass);
@@ -508,6 +509,36 @@ public final class ChronicleMapBuilder<K, V> implements
 
     String name() {
         return this.name;
+    }
+
+    /**
+     * Controls how {@link #create()} reacts when the configured key type would be stored using
+     * default Java serialization. Java serialization does not guarantee a canonical byte form for
+     * {@code equals()}-equal objects: object graph sharing, collection ordering, and serialized
+     * fields ignored by {@code equals()} can all produce different byte streams.
+     *
+     * <p>Chronicle Map identifies keys purely by their serialized bytes. If equal keys serialize to
+     * different bytes, they are stored and looked up as <em>distinct</em> keys. By default a key
+     * using fallback Java serialization produces a warning at build time; enabling strict mode
+     * makes {@link #create()} throw {@link IllegalArgumentException} instead.
+     *
+     * <p>The remedy in either case is to supply a custom, canonical serialized form via {@link
+     * #keyReaderAndDataAccess(SizedReader, DataAccess)}. Strict mode can also be enabled globally
+     * with the {@code
+     * chronicle.map.strictSerializedKeyIdentity} system property.
+     *
+     * <p>This option guards specifically against Chronicle Map's automatic fallback to Java
+     * serialization. An explicitly supplied {@link DataAccess} is trusted and is not inspected for
+     * canonical output; the caller must ensure that it emits identical bytes for equal keys.
+     * Leaving this option disabled preserves compatibility by warning and proceeding, so it does
+     * not make a fallback-Java-serialized key safe.
+     *
+     * @param strict {@code true} to fail fast, {@code false} (default) to only warn
+     * @return this builder back, for chaining
+     */
+    public ChronicleMapBuilder<K, V> strictSerializedKeyIdentity(final boolean strict) {
+        this.strictSerializedKeyIdentity = strict;
+        return this;
     }
 
     /**
@@ -2018,6 +2049,36 @@ public final class ChronicleMapBuilder<K, V> implements
     private void stateChecks() {
         checkActualChunksPerSegmentTierIsConfiguredOnlyIfOtherLowLevelConfigsAreManual();
         checkActualChunksPerSegmentGreaterOrEqualToEntries();
+        checkSerializedKeyIdentity();
+    }
+
+    /**
+     * Chronicle Map identifies keys by their serialized bytes. A key type stored with default Java
+     * serialization (the fallback when no more specific marshaller applies and the user configured
+     * no custom {@link DataAccess}) is not guaranteed to serialize equal instances to identical
+     * bytes. Object graph sharing, collection ordering, and serialized fields ignored by
+     * {@code equals()} can all break that assumption. Warn for every fallback Java-serialized key
+     * type by default; fail fast for every such type when strict mode is enabled. Explicitly
+     * configured serialization is trusted rather than inspected and must be canonical by contract.
+     *
+     * @see #strictSerializedKeyIdentity(boolean)
+     */
+    private void checkSerializedKeyIdentity() {
+        final Class<K> keyClass = keyBuilder.tClass;
+        if (keyBuilder.usesDefaultJavaSerialization()) {
+            final String message = "Key type " + keyClass.getName() + " is stored with fallback " +
+                    "Java serialization. Chronicle Map identifies keys by their serialized bytes, " +
+                    "but Java serialization does not guarantee identical bytes for equals()-equal " +
+                    "objects (for example, object graph sharing, collection ordering, or fields " +
+                    "ignored by equals() can change the stream). Such keys can therefore be stored " +
+                    "and looked up as distinct keys. Provide a canonical serialized form with " +
+                    "keyReaderAndDataAccess(SizedReader, DataAccess). Set system property " +
+                    "'chronicle.map.strictSerializedKeyIdentity' or call " +
+                    "strictSerializedKeyIdentity(true) to fail fast instead of warning.";
+            if (strictSerializedKeyIdentity)
+                throw new IllegalArgumentException(message);
+            Jvm.warn().on(getClass(), message);
+        }
     }
 
     private boolean allLowLevelConfigurationsAreManual() {

--- a/src/test/java/net/openhft/chronicle/map/SerializedKeyIdentityTest.java
+++ b/src/test/java/net/openhft/chronicle/map/SerializedKeyIdentityTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.map;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.onoes.ExceptionKey;
+import net.openhft.chronicle.core.onoes.LogLevel;
+import net.openhft.chronicle.hash.serialization.impl.SerializableDataAccess;
+import net.openhft.chronicle.hash.serialization.impl.SerializableReader;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Regression coverage for Chronicle-Map#462. */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class SerializedKeyIdentityTest {
+
+    /**
+     * The reporter's mechanism: sorted iteration order is identical, but one object graph contains
+     * two equal strings while the other reuses one string. Java serialization records that sharing
+     * with a back-reference, so the streams differ despite equal maps and equal iteration order.
+     */
+    @Test
+    public void equalTreeMapsWithDifferentReferenceSharingSerializeDifferently()
+            throws IOException {
+        final String distinctKey = new String("0");
+        final String distinctValue = new String("0");
+        final TreeMap<String, String> distinctReferences = new TreeMap<>();
+        distinctReferences.put(distinctKey, distinctValue);
+
+        final String shared = new String("0");
+        final TreeMap<String, String> sharedReference = new TreeMap<>();
+        sharedReference.put(shared, shared);
+
+        assertEquals(distinctReferences, sharedReference);
+        assertEquals(distinctReferences.entrySet().toString(),
+                sharedReference.entrySet().toString());
+        assertNotSame(distinctKey, distinctValue);
+        assertSame(sharedReference.firstKey(), sharedReference.get(sharedReference.firstKey()));
+        assertFalse(Arrays.equals(javaSerialize(distinctReferences),
+                javaSerialize(sharedReference)));
+    }
+
+    /** The exact shared-reference mismatch makes an equal TreeMap key unfindable. */
+    @Test
+    public void equalTreeMapKeyWithDifferentReferenceSharingIsNotFound() {
+        final String distinctKey = new String("0");
+        final String distinctValue = new String("0");
+        final TreeMap<String, String> putKey = new TreeMap<>();
+        putKey.put(distinctKey, distinctValue);
+
+        final String shared = new String("0");
+        final TreeMap<String, String> lookupKey = new TreeMap<>();
+        lookupKey.put(shared, shared);
+        assertEquals(putKey, lookupKey);
+
+        try (ChronicleMap<TreeMap, String> map = ChronicleMap
+                .of(TreeMap.class, String.class)
+                .entries(16)
+                .averageKey(putKey)
+                .averageValueSize(8)
+                .create()) {
+            map.put(putKey, "value");
+            assertTrue(map.containsKey(putKey));
+            assertFalse("an equal key with different serialized bytes is not found",
+                    map.containsKey(lookupKey));
+        }
+    }
+
+    /** In strict mode every fallback Java-serialized key type is rejected, not just containers. */
+    @Test
+    public void strictModeRejectsNonContainerKeyWhoseEqualsIgnoresAField() {
+        assertStrictRejects(ChronicleMap
+                .of(Key.class, String.class)
+                .entries(16)
+                .averageKeySize(64)
+                .averageValueSize(8)
+                .strictSerializedKeyIdentity(true));
+    }
+
+    /** A declared supertype cannot hide a runtime Map from the strict fallback check. */
+    @Test
+    public void strictModeRejectsDeclaredSupertype() {
+        assertStrictRejects(ChronicleMap
+                .of(Object.class, String.class)
+                .entries(16)
+                .averageKeySize(64)
+                .averageValueSize(8)
+                .strictSerializedKeyIdentity(true));
+    }
+
+    /** Explicit serialization is the escape hatch, even if it deliberately uses the same codec. */
+    @Test
+    public void customDataAccessIsExemptFromStrictFallbackCheck() {
+        try (ChronicleMap<Key, String> map = ChronicleMap
+                .of(Key.class, String.class)
+                .entries(16)
+                .averageKeySize(64)
+                .averageValueSize(8)
+                .keyReaderAndDataAccess(new SerializableReader<>(),
+                        new SerializableDataAccess<>())
+                .strictSerializedKeyIdentity(true)
+                .create()) {
+            map.put(new Key(1, "A"), "value");
+            assertEquals("value", map.get(new Key(1, "A")));
+            assertNull("strict mode trusts, but cannot canonicalize, explicit DataAccess",
+                    map.get(new Key(1, "B")));
+        }
+    }
+
+    /** Default mode records a diagnostic and still permits creation for compatibility. */
+    @Test
+    public void defaultModeWarnsForFallbackJavaSerialization() {
+        final Map<ExceptionKey, Integer> events = Jvm.recordExceptions(false, false, false);
+        try {
+            try (ChronicleMap<Key, String> ignored = ChronicleMap
+                    .of(Key.class, String.class)
+                    .entries(16)
+                    .averageKeySize(64)
+                    .averageValueSize(8)
+                    .create()) {
+                assertTrue(ignored.isEmpty());
+            }
+        } finally {
+            Jvm.resetExceptionHandlers();
+        }
+
+        assertTrue("expected the serialized-key identity warning",
+                events.keySet().stream().anyMatch(event ->
+                        event.level() == LogLevel.WARN &&
+                                event.message().contains("fallback Java serialization") &&
+                                event.message().contains(Key.class.getName())));
+    }
+
+    /** The system property is evaluated for each new builder and enables the same strict check. */
+    @Test
+    public void systemPropertyEnablesStrictMode() {
+        final String property = "chronicle.map.strictSerializedKeyIdentity";
+        final String previous = System.getProperty(property);
+        System.setProperty(property, "true");
+        try {
+            assertStrictRejects(ChronicleMap
+                    .of(Key.class, String.class)
+                    .entries(16)
+                    .averageKeySize(64)
+                    .averageValueSize(8));
+        } finally {
+            if (previous == null)
+                System.clearProperty(property);
+            else
+                System.setProperty(property, previous);
+        }
+    }
+
+    /** The insertion-order example remains useful as an additional, distinct failure mechanism. */
+    @Test
+    public void equalLinkedHashMapsCanSerializeToDifferentBytes() throws IOException {
+        final LinkedHashMap<String, String> first = new LinkedHashMap<>();
+        first.put("x", "1");
+        first.put("y", "2");
+        final LinkedHashMap<String, String> second = new LinkedHashMap<>();
+        second.put("y", "2");
+        second.put("x", "1");
+
+        assertEquals(first, second);
+        assertFalse(Arrays.equals(javaSerialize(first), javaSerialize(second)));
+    }
+
+    private static void assertStrictRejects(ChronicleMapBuilder<?, String> builder) {
+        try {
+            builder.create().close();
+            fail("expected strict mode to reject fallback Java serialization");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("serialized bytes"));
+        }
+    }
+
+    private static byte[] javaSerialize(Serializable value) throws IOException {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(value);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static final class Key implements Serializable {
+        private static final long serialVersionUID = 0L;
+
+        private final int id;
+        private final String label;
+
+        private Key(int id, String label) {
+            this.id = id;
+            this.label = label;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            return object instanceof Key && id == ((Key) object).id;
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `ec649062438ef6f706a493945608d44dbb3df3dc` into the existing branch with normal forward commits. Updated head: `9183026c4ecebf08db9fa7dce722213afd0331ae`. Both develop `ec649062438ef6f706a493945608d44dbb3df3dc` and the declared parent are ancestors of this head; both missing-commit counts are zero.

Retained current persisted-header and worker-failure fixes. Full clean verify passed on Java 21: 1,333 reported tests, 82 skipped.

Strict/warning policy, custom DataAccess and persisted-key compatibility remain explicit review boundaries; repository tests do not qualify all existing persisted consumers.

Local runs used Linux x86-64 and OpenJDK 21.0.12 unless Java 8 is explicitly stated (8u502). Reported test counts include skips. Commands requested zero Surefire reruns. Draft status and declared target are retained.

Earlier implementation/review notes follow. Earlier validation and performance claims apply only to their stated revisions and are superseded by the current receipt above where they differ.

---

## What changed

Local `207c8c94` detects Java-serialised container keys at builder time and supplies warning/strict behaviour plus tests.

## Why

This publishes the reviewed local solution for [#462](https://github.com/OpenHFT/Chronicle-Map/issues/462) so the implementation can be discussed in the normal review workflow.



## Review status

**Draft — coherent local solution, not yet merge-ready.**

Before marking ready: Review compatibility of the new surface and custom `DataAccess` documentation, then publish.

## Validation

- `git diff --check` against `ea`: passed.
- Internal `.pr/` scaffolding and local workspace paths: removed.
- Focused validation recorded by the backlog audit is described above; it was not rerun during this publication pass.
- Remote CI and maintainer review are still required.

## Tracking

Fixes #462