### PR TITLE
Require successful initial opening in the recovery test

### DIFF
--- a/src/test/java/net/openhft/chronicle/map/Issue229Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue229Test.java
@@ -12,8 +12,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 public class Issue229Test {
 
@@ -29,7 +31,7 @@ public class Issue229Test {
         mapFile.delete();
     }
 
-    @Test(expected = ChronicleHashRecoveryFailedException.class)
+    @Test
     public void assureExclusiveAccess() throws IOException {
         Assume.assumeFalse(OS.isWindows());
 
@@ -39,13 +41,18 @@ public class Issue229Test {
                 .createPersistedTo(mapFile)) {
             assertNotNull(readMap);
 
-            // It shall not be possible to recover since the
-            // file is open by the readMap
-            try (ChronicleMap<Long, Long> recoverMap = ChronicleMap
+            ChronicleMapBuilder<Long, Long> recoveryBuilder = ChronicleMap
                     .of(Long.class, Long.class)
-                    .entries(10)
-                    .recoverPersistedTo(mapFile, true)) {
-                assertNotNull(recoverMap);
+                    .entries(10);
+            AtomicReference<ChronicleMap<Long, Long>> unexpectedRecovery = new AtomicReference<>();
+            try {
+                //! Only recovery may supply the expected failure; opening and cleanup must succeed independently.
+                assertThrows(ChronicleHashRecoveryFailedException.class,
+                        () -> unexpectedRecovery.set(recoveryBuilder.recoverPersistedTo(mapFile, true)));
+            } finally {
+                ChronicleMap<Long, Long> recoveredMap = unexpectedRecovery.get();
+                if (recoveredMap != null)
+                    recoveredMap.close();
             }
         }
     }

--- a/src/test/java/net/openhft/chronicle/map/Issue229Test.java
+++ b/src/test/java/net/openhft/chronicle/map/Issue229Test.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.map;
 
 import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.hash.ChronicleHashRecoveryFailedException;
 import org.junit.After;
 import org.junit.Assume;
@@ -46,13 +47,11 @@ public class Issue229Test {
                     .entries(10);
             AtomicReference<ChronicleMap<Long, Long>> unexpectedRecovery = new AtomicReference<>();
             try {
-                //! Only recovery may supply the expected failure; opening and cleanup must succeed independently.
+                //! Only recovery may supply the expected failure; opening and cleanup stay outside the assertion.
                 assertThrows(ChronicleHashRecoveryFailedException.class,
                         () -> unexpectedRecovery.set(recoveryBuilder.recoverPersistedTo(mapFile, true)));
             } finally {
-                ChronicleMap<Long, Long> recoveredMap = unexpectedRecovery.get();
-                if (recoveredMap != null)
-                    recoveredMap.close();
+                Closeable.closeQuietly(unexpectedRecovery.get());
             }
         }
     }


### PR DESCRIPTION
`Issue229Test` previously accepted `ChronicleHashRecoveryFailedException` anywhere in the test, including the initial Map opening. Require that opening to succeed, then use JUnit 4's `assertThrows` around recovery alone. Use `Closeable.closeQuietly(unexpectedRecovery.get())` for null-safe cleanup outside that assertion, so cleanup cannot satisfy the expected recovery failure.

This extracts the exception-scope improvement identified in #588. It changes one test class and keeps the existing framework and POM.

Validation:

- `mvn clean verify -Dtest=Issue229Test -Dsurefire.rerunFailingTestsCount=0` passed on Java 21 and Java 8 after the `closeQuietly` revision (one test, no skips).
- Fault-injected copies of the actual JUnit test: an initial-opening recovery exception passed the original annotation-based test and failed this version.
- Deliberately closing the first Map before recovery made recovery succeed: the revised test failed as expected and confirmed the returned Map was closed.

CI evidence for the preceding head, `215114709dd5bb6564ff7416827083c843e77e28`: nine supported contexts passed; [Mac build 316](https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleMap_SnapshotMac/1349114) failed with two assertion failures and 13 errors. The supplied Mac log explicitly reports `Issue229Test`: one test, zero failures/errors/skips. Its earlier failures include `ConcurrentModificationException` at `MyJavaFileManager.addFileObjects` in Chronicle Values, followed by value-generation and serialised-size errors. This is separate from the recovery assertion being changed here; a Mac rerun has not been verified for the `closeQuietly` revision.

Java 26 and later checks are informational, not merge blockers. Their failures are not included in the supported-CI assessment above.

<details>
<summary>Validation environment and dependency receipt</summary>

Linux x86_64; Maven 3.9.11; OpenJDK 21.0.12 and 8u502. Surefire 3.1.2, JUnit 4.13.2, Vintage 5.10.0. Failing-test reruns explicitly disabled with `-Dsurefire.rerunFailingTestsCount=0`. Builds start from `develop` at `0c25269da8d12e3e1cd10c7f4c74ae35a017ab2c`.

Resolved Chronicle dependencies: Core 2026.6; Bytes 2026.4; Wire 2026.10-SNAPSHOT; Values 2026.2; Threads 2026.3; Algorithms 2026.2; Affinity 2026.2; Posix 2026.2; Test Framework 2026.2; JLBH 2026.2. Parent and third-party BOM: 2026.0. XStream: 1.4.21.

Mutable-input SHA-256:

```text
chronicle-bom-2026.0-SNAPSHOT.pom  5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0
chronicle-wire-2026.10-SNAPSHOT.jar  77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87
```

The unchanged baseline also passed full `mvn verify`: 1,316 tests, 82 existing skips. Windows/macOS and downstream projects were not run locally.

</details>
