### PR TITLE
Record JUnit assertion failures from JSR166 worker helpers

### DIFF
--- a/src/test/java/net/openhft/chronicle/map/jsr166/JSR166TestCase.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/JSR166TestCase.java
@@ -277,27 +277,28 @@ public class JSR166TestCase {
 
     /**
      * Just like Assert.fail(reason), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadFail(String reason) {
         try {
             Assert.fail(reason);
-        } catch (AssertionFailedError t) {
+            //! JUnit 4 throws AssertionError, which is not caught by the JUnit 3 AssertionFailedError subtype.
+        } catch (AssertionError t) {
             threadRecordFailure(t);
-            Assert.fail(reason);
+            throw t;
         }
     }
 
     /**
      * Just like Assert.assertTrue(b), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadAssertTrue(boolean b) {
         try {
             Assert.assertTrue(b);
-        } catch (AssertionFailedError t) {
+        } catch (AssertionError t) {
             threadRecordFailure(t);
             throw t;
         }
@@ -305,13 +306,13 @@ public class JSR166TestCase {
 
     /**
      * Just like assertFalse(b), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadAssertFalse(boolean b) {
         try {
             Assert.assertFalse(b);
-        } catch (AssertionFailedError t) {
+        } catch (AssertionError t) {
             threadRecordFailure(t);
             throw t;
         }
@@ -319,13 +320,13 @@ public class JSR166TestCase {
 
     /**
      * Just like assertNull(x), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadAssertNull(Object x) {
         try {
             Assert.assertNull(x);
-        } catch (AssertionFailedError t) {
+        } catch (AssertionError t) {
             threadRecordFailure(t);
             throw t;
         }
@@ -333,13 +334,13 @@ public class JSR166TestCase {
 
     /**
      * Just like assertEquals(x, y), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadAssertEquals(long x, long y) {
         try {
             Assert.assertEquals(x, y);
-        } catch (AssertionFailedError t) {
+        } catch (AssertionError t) {
             threadRecordFailure(t);
             throw t;
         }
@@ -347,13 +348,13 @@ public class JSR166TestCase {
 
     /**
      * Just like assertEquals(x, y), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadAssertEquals(Object x, Object y) {
         try {
             Assert.assertEquals(x, y);
-        } catch (AssertionFailedError t) {
+        } catch (AssertionError t) {
             threadRecordFailure(t);
             throw t;
         } catch (Throwable t) {
@@ -363,13 +364,13 @@ public class JSR166TestCase {
 
     /**
      * Just like assertSame(x, y), but additionally recording (using
-     * threadRecordFailure) any AssertionFailedError thrown, so that
+     * threadRecordFailure) any AssertionError thrown, so that
      * the current testcase will Assert.fail.
      */
     public void threadAssertSame(Object x, Object y) {
         try {
             Assert.assertSame(x, y);
-        } catch (AssertionFailedError t) {
+        } catch (AssertionError t) {
             threadRecordFailure(t);
             throw t;
         }

--- a/src/test/java/net/openhft/chronicle/map/jsr166/JSR166ThreadFailureTest.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/JSR166ThreadFailureTest.java
@@ -67,7 +67,7 @@ public class JSR166ThreadFailureTest {
             // Observe the uncaught failure without recording it on the fixture's behalf.
             worker.setUncaughtExceptionHandler((thread, failure) -> workerFailure.set(failure));
             worker.start();
-            worker.join(5_000);
+            worker.join(LONG_DELAY_MS);
             assertFalse("worker did not terminate", worker.isAlive());
         }
     }

--- a/src/test/java/net/openhft/chronicle/map/jsr166/JSR166ThreadFailureTest.java
+++ b/src/test/java/net/openhft/chronicle/map/jsr166/JSR166ThreadFailureTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.map.jsr166;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class JSR166ThreadFailureTest {
+    private final Consumer<JSR166TestCase> assertion;
+
+    public JSR166ThreadFailureTest(String name, Consumer<JSR166TestCase> assertion) {
+        this.assertion = assertion;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> assertions() {
+        return Arrays.asList(new Object[][]{
+                {"fail", (Consumer<JSR166TestCase>) test -> test.threadFail("worker failure")},
+                {"true", (Consumer<JSR166TestCase>) test -> test.threadAssertTrue(false)},
+                {"false", (Consumer<JSR166TestCase>) test -> test.threadAssertFalse(true)},
+                {"null", (Consumer<JSR166TestCase>) test -> test.threadAssertNull(new Object())},
+                {"long equality", (Consumer<JSR166TestCase>) test -> test.threadAssertEquals(1L, 2L)},
+                {"object equality", (Consumer<JSR166TestCase>) test -> test.threadAssertEquals(new Object(), new Object())},
+                {"string equality", (Consumer<JSR166TestCase>) test -> test.threadAssertEquals("expected", "actual")},
+                {"identity", (Consumer<JSR166TestCase>) test -> test.threadAssertSame(new Object(), new Object())}
+        });
+    }
+
+    @Test
+    public void workerFailureFailsOwningJUnitInvocation() throws Exception {
+        WorkerFixture fixture = new WorkerFixture();
+        fixture.assertion = assertion;
+        Result result = new JUnitCore().run(new BlockJUnit4ClassRunner(WorkerFixture.class) {
+            @Override
+            protected Object createTest() {
+                return fixture;
+            }
+        });
+
+        assertEquals(1, result.getRunCount());
+        assertTrue("the worker must rethrow its assertion", fixture.workerFailure.get() instanceof AssertionError);
+        assertEquals("the owning JUnit invocation must fail", 1, result.getFailureCount());
+        //! Matching the original throwable excludes failures caused only by fixture setup or worker joining.
+        assertSame(fixture.workerFailure.get(), result.getFailures().get(0).getException());
+    }
+
+    public static class WorkerFixture extends JSR166TestCase {
+        private Consumer<JSR166TestCase> assertion;
+        private final AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+
+        @Test
+        public void runWorkerAssertion() throws InterruptedException {
+            Thread worker = new Thread(() -> assertion.accept(this), "jsr166-assertion-worker");
+            // Observe the uncaught failure without recording it on the fixture's behalf.
+            worker.setUncaughtExceptionHandler((thread, failure) -> workerFailure.set(failure));
+            worker.start();
+            worker.join(5_000);
+            assertFalse("worker did not terminate", worker.isAlive());
+        }
+    }
+}


### PR DESCRIPTION
`JSR166TestCase` calls JUnit 4 assertions but catches the narrower JUnit 3 `AssertionFailedError`. A failing worker can therefore terminate without recording the failure for the owning test. Catch `AssertionError`, record it, and rethrow the original throwable.

A parameterised regression runs real worker threads inside an owning JUnit invocation, joins them, and checks that JUnit reports the exact throwable observed by the worker's uncaught-exception handler. The handler only observes the failure; the helper and inherited teardown must propagate it.

Validation:

- With the old helpers, six of eight regression cases failed because the owning JUnit invocation incorrectly passed. Object/string equality already recorded failures through its broader catch.
- With the fix, all eight cases pass. Both existing Map subclasses also pass: 88 tests total, three pre-existing skips, on Java 21 and a clean Java 8 build.
- Command: `mvn verify -Dtest=JSR166ThreadFailureTest,net.openhft.chronicle.map.jsr166.map.ChronicleMapTest,ReplicatedChronicleMapTest -Dsurefire.rerunFailingTestsCount=0`.

This is a conditional test-infrastructure extraction from #588. A source search found no active pre-existing test consumer of these worker helpers; the demonstrated benefit is enforcing their documented contract, not additional Map scenario coverage. Kept as a draft for that prioritisation decision. JUnit and POM are unchanged.


<details>
<summary>Validation environment and dependency receipt</summary>

Linux x86_64; Maven 3.9.11; OpenJDK 21.0.12 and 8u502. Surefire 3.1.2, JUnit 4.13.2, Vintage 5.10.0. Failing-test reruns explicitly disabled with `-Dsurefire.rerunFailingTestsCount=0`. Builds start from `develop` at `0c25269da8d12e3e1cd10c7f4c74ae35a017ab2c`.

Resolved Chronicle dependencies: Core 2026.6; Bytes 2026.4; Wire 2026.10-SNAPSHOT; Values 2026.2; Threads 2026.3; Algorithms 2026.2; Affinity 2026.2; Posix 2026.2; Test Framework 2026.2; JLBH 2026.2. Parent and third-party BOM: 2026.0. XStream: 1.4.21.

Mutable-input SHA-256:

```text
chronicle-bom-2026.0-SNAPSHOT.pom  5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0
chronicle-wire-2026.10-SNAPSHOT.jar  77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87
```

The unchanged baseline also passed full `mvn verify`: 1,316 tests, 82 existing skips. Windows/macOS and downstream projects were not run locally.

</details>

