### PR TITLE
Preserve Java 8 buffer descriptors in persisted Map I/O

### DIFF
--- a/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
+++ b/src/main/java/net/openhft/chronicle/hash/impl/VanillaChronicleHash.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
@@ -425,7 +426,8 @@ public abstract class VanillaChronicleHash<K,
                     throw throwRecoveryOrReturnIOException(file, "truncated", recover);
                 }
             }
-            globalMutableStateBuffer.flip();
+            //! Keep the Java 8 Buffer descriptor when this reopening path is compiled on newer JDKs.
+            ((Buffer) globalMutableStateBuffer).flip();
             //noinspection unchecked
             globalMutableState.bytesStore(BytesStore.wrap(globalMutableStateBuffer), 0, globalMutableState.maxSize());
         }

--- a/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
+++ b/src/main/java/net/openhft/chronicle/map/ChronicleMapBuilder.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.HashMap;
@@ -356,7 +357,8 @@ public final class ChronicleMapBuilder<K, V> implements
                                          final int headerSize) throws IOException {
         //noinspection PointlessBitwiseExpression
         headerBuffer.putInt(SIZE_WORD_OFFSET, NOT_COMPLETE | DATA | headerSize);
-        headerBuffer.clear().position(SIZE_WORD_OFFSET).limit(SIZE_WORD_OFFSET + 4);
+        //! Buffer views preserve Java 8 call descriptors when compiling on newer JDKs.
+        ((Buffer) headerBuffer).clear().position(SIZE_WORD_OFFSET).limit(SIZE_WORD_OFFSET + 4);
         writeFully(fileChannel, SIZE_WORD_OFFSET, headerBuffer);
     }
 
@@ -388,11 +390,12 @@ public final class ChronicleMapBuilder<K, V> implements
         headerBuffer.putInt(SIZE_WORD_OFFSET, NOT_COMPLETE | DATA | headerSize);
 
         // Write the size-prefixed blob to the file
-        headerBuffer.position(0);
-        headerBuffer.limit(headerLimit);
+        final Buffer headerView = headerBuffer;
+        headerView.position(0);
+        headerView.limit(headerLimit);
         writeFully(fileChannel, 0, headerBuffer);
 
-        headerBuffer.position(SELF_BOOTSTRAPPING_HEADER_OFFSET);
+        headerView.position(SELF_BOOTSTRAPPING_HEADER_OFFSET);
         return headerBuffer;
     }
 
@@ -406,7 +409,7 @@ public final class ChronicleMapBuilder<K, V> implements
 
         //noinspection PointlessBitwiseExpression
         headerBuffer.putInt(SIZE_WORD_OFFSET, READY | DATA | headerSize);
-        headerBuffer.clear().position(SIZE_WORD_OFFSET).limit(SIZE_WORD_OFFSET + 4);
+        ((Buffer) headerBuffer).clear().position(SIZE_WORD_OFFSET).limit(SIZE_WORD_OFFSET + 4);
         writeFully(fileChannel, SIZE_WORD_OFFSET, headerBuffer);
     }
 
@@ -446,7 +449,7 @@ public final class ChronicleMapBuilder<K, V> implements
                 throw new IOException("file=" + file + ": sizeWord is not ready: " + sizeWord);
             }
         }
-        headerBuffer.position(SELF_BOOTSTRAPPING_HEADER_OFFSET);
+        ((Buffer) headerBuffer).position(SELF_BOOTSTRAPPING_HEADER_OFFSET);
         return headerBuffer;
     }
 
@@ -1789,7 +1792,7 @@ public final class ChronicleMapBuilder<K, V> implements
         for (int attempt = 0; attempt < attempts; attempt++) {
             if (raf.length() >= SELF_BOOTSTRAPPING_HEADER_OFFSET) {
 
-                sizeWordBuffer.clear();
+                ((Buffer) sizeWordBuffer).clear();
                 readFully(fileChannel, SIZE_WORD_OFFSET, sizeWordBuffer);
                 if (sizeWordBuffer.remaining() == 0) {
                     int sizeWord = sizeWordBuffer.getInt(0);

--- a/src/test/java/net/openhft/chronicle/map/PersistedMapHeaderTest.java
+++ b/src/test/java/net/openhft/chronicle/map/PersistedMapHeaderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class PersistedMapHeaderTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = TemporaryFolder.builder().assureDeletion().build();
+
+    @Test
+    public void createReopenAndRecoverPreserveEntries() throws IOException {
+        File file = temporaryFolder.newFile("header.map");
+        ChronicleMapBuilder<Long, Long> builder = ChronicleMap.of(Long.class, Long.class).entries(10);
+
+        try (ChronicleMap<Long, Long> created = builder.createPersistedTo(file)) {
+            created.put(1L, 42L);
+            assertEquals(Long.valueOf(42L), created.get(1L));
+        }
+        try (ChronicleMap<Long, Long> reopened = builder.createPersistedTo(file)) {
+            assertEquals(Long.valueOf(42L), reopened.get(1L));
+            reopened.put(2L, 43L);
+        }
+        try (ChronicleMap<Long, Long> recovered = builder.recoverPersistedTo(file, true)) {
+            assertEquals(2, recovered.size());
+            assertEquals(Long.valueOf(42L), recovered.get(1L));
+            assertEquals(Long.valueOf(43L), recovered.get(2L));
+        }
+        try (ChronicleMap<Long, Long> reopened = builder.createPersistedTo(file)) {
+            assertEquals(2, reopened.size());
+            assertEquals(Long.valueOf(42L), reopened.get(1L));
+            assertEquals(Long.valueOf(43L), reopened.get(2L));
+        }
+    }
+}


### PR DESCRIPTION
A Chronicle Map artifact compiled on a modern JDK with Java 8 source/target settings can link header cursor operations to Java 9+ covariant `ByteBuffer` methods. On Java 8, creating a persisted Map then fails with `NoSuchMethodError`.

Use `Buffer`-typed cursor calls in `ChronicleMapBuilder` and the global-state read in `VanillaChronicleHash.initBeforeMapping()`. Add a persistence regression that writes entries, reopens the Map, recovers it with exclusive access, and reopens it again while checking retained values and temporary-file deletion.

This extracts the production compatibility work identified in #588. Actual Java 8 execution showed the builder-only changes were incomplete: creation succeeded, but reopening failed at the additional `ByteBuffer.flip()` call. The extra cast fixes that same persistence path. Three files change; the POM and JUnit framework are unchanged.

Validation:

| Java-21-built artifact, executed on Java 8u502 | Result |
| --- | --- |
| Current develop baseline | Fails creating the Map: `ByteBuffer.position(int):ByteBuffer` in `writeHeader()` |
| Builder-only extraction | Creation succeeds; reopening fails: `ByteBuffer.flip():ByteBuffer` in `initBeforeMapping()` |
| Final patch | Create, reopen, recover and reopen-after-recovery pass; key/value assertions and file cleanup pass |

The runtime check verified that `ChronicleMapBuilder` was loaded from the requested packaged JAR. It did not use `target/classes` or rebuild Map on Java 8. Disassembly confirms `Buffer`-returning cursor descriptors at all changed call sites.

Full `mvn verify -Dsurefire.rerunFailingTestsCount=0` on Java 21 passed: 1,317 tests, 82 existing skips. The baseline had 1,316 tests and the same skip count. The binary compatibility enforcer also passed.

<details>
<summary>Reproduce the packaged-artifact check</summary>

With `JAVA_HOME` and `PATH` pointing to JDK 21 for Maven:

```bash
mvn clean verify -Dsurefire.rerunFailingTestsCount=0 -l verify-java21.log
mvn dependency:build-classpath -Dmdep.outputFile=target/test-classpath.txt
map_test_deps=$(cat target/test-classpath.txt)
/path/to/jdk8/bin/java -ea \
  -cp "target/test-classes:target/chronicle-map-2026.2-SNAPSHOT.jar:$map_test_deps" \
  org.junit.runner.JUnitCore net.openhft.chronicle.map.PersistedMapHeaderTest
```

Validated final JAR SHA-256: `ef49507dd461f8147ec512230b7cdeb56e6adadc045ab10c589eac83a723a739`.

</details>

<details>
<summary>Validation environment and dependency receipt</summary>

Linux x86_64; Maven 3.9.11; OpenJDK 21.0.12 and 8u502. Surefire 3.1.2, JUnit 4.13.2, Vintage 5.10.0. Failing-test reruns explicitly disabled with `-Dsurefire.rerunFailingTestsCount=0`. Builds start from `develop` at `0c25269da8d12e3e1cd10c7f4c74ae35a017ab2c`.

Resolved Chronicle dependencies: Core 2026.6; Bytes 2026.4; Wire 2026.10-SNAPSHOT; Values 2026.2; Threads 2026.3; Algorithms 2026.2; Affinity 2026.2; Posix 2026.2; Test Framework 2026.2; JLBH 2026.2. Parent and third-party BOM: 2026.0. XStream: 1.4.21.

Mutable-input SHA-256:

```text
chronicle-bom-2026.0-SNAPSHOT.pom  5e9ce529e8aaa9f9930658b2ef59222ebffe164fb8e6d31ce0b4e204cb1d55a0
chronicle-wire-2026.10-SNAPSHOT.jar  77afd5d4236c738c25980c268858879b6c929e70486b829b5e4a434dd6b31c87
```

The unchanged baseline also passed full `mvn verify`: 1,316 tests, 82 existing skips. Windows/macOS and downstream projects were not run locally.

</details>

